### PR TITLE
Update: improve upgrade check

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ It includes a simple graphical user interface (**gui**): not impressive visually
 Support for multiplayer/competitive modes such as races, bosses, contested territory, boss rush, etc. will not be 
 added.
 
-Bot is recommended to run on resolutions with **16:9** aspect ratio, with **fullscreen enabled**. 
-However, you can probably run it on any resolution where in-game actions are centered in a 16:9 screen.  
-For example, with ``3440x1440``, the actual game screen is ``2560x1440`` which has exactly 16:9 ratio.
+Bot should be run on resolutions with **16:9** aspect ratio, with **fullscreen enabled**. 
+However, it does support *windowed mode* and you can probably run it on any resolution where in-game actions are 
+centered in a 16:9 area with some tricks which are explained later.
+For example, with ``3440x1440``, the actual game screen area is ``2560x1440`` which has exactly 16:9 ratio.  
+
+**If you have any questions or problems you can&39;t figure out, feel free to create a new issue on github.** 
 
 ---
 **[Update status]  
@@ -24,7 +27,7 @@ Tested only on Windows operating systems**
 **-- Warning --**  
 ***Be aware that automation/botting is againts Ninja Kiwi&#39;s [Terms of Service](https://ninjakiwi.com/terms) and
 imposes the risk of flagging your account for cheating, or worst case, getting it banned.  
-I&#39;m not certain how Ninja Kiwi could enforce this in single player environment, though. But if you&#39;re concerned,
+I&#39;m not certain how they could enforce this in single player environment, though. But if you&#39;re concerned,
 you can always run the bot offline. <u>You have been warned</u>.***
 
 
@@ -93,8 +96,8 @@ adding new content.
 
 # <u>Installation</u>
 First you need to install [Python](https://www.python.org/downloads/).  
-Most of bot functions were programmed in Python versions 3.12 and 3.13 so **Python 3.12+** is recommended.  
-It is likely to work on some earlier versions of Python 3, but this has not been tested.
+Most of bot was programmed in Python versions 3.12 and 3.13 so **Python 3.12+** is recommended.  
+It is likely to work on earlier versions of Python 3, but this has not been tested.
 
 Now, download *BTD6bot*:
 
@@ -121,7 +124,8 @@ Next, the external dependencies. Install the following third party packages:
 
 Install them by going to your BTD6bot folder, then run ``reqs.bat``. 
 
-If this isn&#39;t working: run cmd, change your current directory to where you installed BTD6bot, then type
+If this isn&#39;t working: run cmd, change your current directory to ``<your path>/btd6bot`` where you installed
+BTD6bot, then type
 ``
 pip install -r requirements.txt
 ``
@@ -132,7 +136,7 @@ above 1.7.8 cause a fatal error when any gui hotkeys are used.
 And that&#39;s it! You&#39;re good to go and should be able to start BTD6bot. To test this, try one of the following:
 
 - Open your BTD6bot folder, then run the ``run.bat`` file
-- Open cmd, set current directory to BTD6bot install folder, then type ``py btd6bot ``
+- Open cmd, set current directory to ``<your path>/btd6bot`` then type ``py btd6bot ``
 
 
 # <u>First-time setup</u>
@@ -162,25 +166,32 @@ should something break irrevocably.**
 ## Quick tutorial:
 
 *1920x1080 monitor is used below; your values can look different*  
-*1600x900 is used as custom resolution* 
+*1600x900 is used as custom resolution example* 
 
 1. Set hotkeys in **Set hotkeys** window; gui hotkeys are not mandatory, but very much recommended. After you&#39;re
 done, close hotkeys window.
 2. Open **Settings** window and set resolution. 
 
-    **Select a resolution with aspect ratio of 16:9, or one that can be reduced to 16:9 by using windowed mode.
-    For latter, read [this](#using-windowed-mode-for-resolutions-with-varying-aspect-ratios)**. 
+    **Select a resolution with aspect ratio of 16:9 AND prefer fullscreen**.
 
-    - If you use fullscreen/windowed fullscreen, **don&#39;t** enable custom resolution.
+    *However, it might be possible to use larger aspect ratios if you use fullscreen in-game, but set bot to use custom resolution and windowed mode in order to limit the area the bot sees; check [this](#using-windowed-mode-for-resolutions-with-varying-aspect-ratios) for more info*. 
+
+    - If you use fullscreen/windowed fullscreen, **don&#39;t** enable custom resolution, or use windowed mode. Just leave it untoggled.
 
         ![](docs/github/images/settings/disable_custom.PNG)
 
     - If you use custom resolution, set width & height values, then update values.
-        - Toggle windowed mode on if you wish to use it. It&#39;s recommended to use fullscreen, though.
-
-        **If windowed mode is enabled, run BTD6 with ``-popupwindow`` launch argument.**
+        - Toggle windowed mode on if you wish to use it. **It&#39;s recommended to always use fullscreen**, and use
+        windowed mode only for *aspect ratios differing from 16:9*, as mentioned before.
 
         ![](docs/github/images/settings/custom_windowed.PNG)
+
+        **If windowed mode is enabled, you must run Btd6 with ``-popupwindow`` launch argument.** E.g. if you use Steam
+        version:  
+        library -> bloons td 6 -> right-click -> properties, then set the following
+
+        ![](docs/github/images/settings/launchoption.PNG)
+
 
 3. Enable ocr auto-adjusting, make sure it has correct res and win values. Res is your current resolution, win stands
 for fullscreen (``win=0``) or windowed (``win=1``).  
@@ -189,12 +200,12 @@ Easiest way is to just press ``Reset args`` button once, then press ``Set args``
 
     ![](docs/github/images/settings/auto_adjust.PNG)
 
-    Now, close settings window. In main window, press **Initialize bot**, then **Open bot window** to open monitoring
-    window.
+    Now, close settings window. In main window, press **Initialize bot**, wait a bit for initialization, then press
+    **Open bot window** to open monitoring window.
     
-    Have your BTD6 game opened on main
-    monitor, placed in main menu screen. Now, run the bot and let it finish auto-adjusting. This process can take a 
-    while.  
+    Have your Btd6 game opened on main
+    monitor, placed in main menu screen with ``Play`` button visible. Now, run the bot and let it finish auto-adjusting.
+    This process can take a while.  
     After adjusting process is finished, bot should be able to detect in-game upgrade texts properly based on your
     current resolution settings.
 
@@ -458,9 +469,9 @@ adjusting may begin.
  2. goes over all the upgrades of listed monkeys, read their upgrade texts, check how closely they match to actual
     texts and save the obtained delta value. Because monkeys=all, it checks all monkeys.
  3. after it checks all listed monkeys once, it will check them again! This time it places them on opposite side of map.
-    Why? Well, if you&#39;re never noticed, depending on which side of middle section you place a monkey (left or right),
-    the monkey panel opens on the opposite side of screen. Different sides can produce slighly different inputs so bot
-    will analyze both sides and save all the deltas.
+    Why? Well, if you&#39;re never noticed, depending on which side of middle section you place a monkey 
+    (left or right), the monkey panel opens on the opposite side of screen. Different sides can produce slighly
+    different inputs so bot will analyze both sides and save all the deltas.
  4. After both sides are checked, both compares deltas of left and right side, selects the smaller value and save it as
     final delta.
  5. To finish things, all delta values are adjusted with equal amount. Default value is 4 i.e. delta=4: this adjust
@@ -570,7 +581,8 @@ version. However, it should have exact same contents as web version so you can u
 
 - It has dark mode always enabled.
 
-- Comes with one major issue: **none of the links work**. Reference links simply point nowhere in document, web links display some random mess so don&#39;t try to use them either.
+- Comes with one major issue: **none of the links work**. Reference links simply point nowhere in document, web links
+display some random mess so don&#39;t try to use them either.
 
 Also something worth to mention: the offline readme is actually an html document translated from the README markdown
 file. Annoyingly, the Python library used for this conversion requires absolutely file paths in order to display all
@@ -631,24 +643,27 @@ which was already used in [First-time setup](#first-time-setup).
     Change resolution the bot uses to determine relative mouse clicking/ocr text locations. Must match with used in-game
     resolution which should approximately have 16:9 aspect ratio.
 - **Windowed mode**: 
-    If Btd6 is run in windowed mode. Btd6 must be launced with -popupwindow lauch option and window cannot be moved from
-    its initial position. 
+    If Btd6 is run in windowed mode. Btd6 must be launced with ``-popupwindow`` launch option and window cannot be moved
+    from its initial position. 
     
     Windowed mode can face issues with ocr accuracy, though. If resolution is considerably smaller, text reading errors
     become more common and can hinder upgrading of monkeys.
 
+    Therefore, **it&#39;s always recommended you use fullscreen if possible.**
+
     #### <u>*Using windowed mode for resolutions with varying aspect ratios*</u>
-    As stated under &#39;Enable custom resolution&#39;, resolutions should have aspect ratios of 16:9 or very close to
-    it.
+    As stated under &#39;Enable custom resolution&#39;, resolutions should have aspect ratio of 16:9. But, it is possible to leave in-game resolution to your native resolution, but still use custom resolution + windowed mode to reduce the actual screen area.
 
     Because windowed mode normally leaves empty space around, you could limit the readable area to the middle of screen.
-    A good example would be 3440x1440 resolution: it adds extra borders during maps which is 440 pixels each side. This
-    means the actual screen area is 3440-440*2=2560 which has aspect ratio of 16:9 with height of 1440! In fact, this
-    should also work for menu screens because play and hero select button are in correct position relative to everything
-    else.
+    A good example would be ``3440x1440`` resolution: it adds extra borders during maps which is 440 pixels each side. This
+    means the actual screen area is 3440-440*2=2560 which has aspect ratio of 16:9 with height of 1440!  
+    In fact, this should also work for menu screens because play and hero select button are in correct position relative
+    to everything else. Only actually problematic case would be the map search button which falls outside the middle
+    area, but there&#39;s a built-in checking system which should be able to locate this button no matter the resolution
+    setting.  
     So if you have a 3440x1440 monitor and wish to play on this resolution, go to gui settings:
 
-    - enable custom resolution and set it as 2560x1440
+    - enable custom resolution and set it as ``2560x1440``
     - enable windowed mode
     - And of course, remember to readjust ocr deltas for new resolution, as always!
 
@@ -668,7 +683,7 @@ which was already used in [First-time setup](#first-time-setup).
     - (optional) if required, you could repeat this for y-resolution as well, but I believe it&#39;s very rare you&#39;d
     need this. One example would be 1280x800 - test this in-game and see how it adds a wider bar on top and bottom of
     the screen.
-    - Then readjust ocr values and you&#39;re good to go.
+    - Then readjust ocr values like usual and you should be good to go.
 
 
 - **Game version**: 

--- a/btd6bot/Files/helpwindow/README.md
+++ b/btd6bot/Files/helpwindow/README.md
@@ -1,6 +1,6 @@
 # BTD6bot
 
-![](docs/github/images/monitoring/monitoring_finish.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/monitoring/monitoring_finish.PNG)
 
 
 ``BTD6bot`` is a program for automating **Bloons Tower Defense 6** game.  
@@ -10,9 +10,12 @@ It includes a simple graphical user interface (**gui**): not impressive visually
 Support for multiplayer/competitive modes such as races, bosses, contested territory, boss rush, etc. will not be 
 added.
 
-Bot is recommended to run on resolutions with **16:9** aspect ratio, with **fullscreen enabled**. 
-However, you can probably run it on any resolution where in-game actions are centered in a 16:9 screen.  
-For example, with ``3440x1440``, the actual game screen is ``2560x1440`` which has exactly 16:9 ratio.
+Bot should be run on resolutions with **16:9** aspect ratio, with **fullscreen enabled**. 
+However, it does support *windowed mode* and you can probably run it on any resolution where in-game actions are 
+centered in a 16:9 area with some tricks which are explained later.
+For example, with ``3440x1440``, the actual game screen area is ``2560x1440`` which has exactly 16:9 ratio.  
+
+**If you have any questions or problems you can&39;t figure out, feel free to create a new issue on github.** 
 
 ---
 **[Update status]  
@@ -24,7 +27,7 @@ Tested only on Windows operating systems**
 **-- Warning --**  
 ***Be aware that automation/botting is againts Ninja Kiwi&#39;s [Terms of Service](https://ninjakiwi.com/terms) and
 imposes the risk of flagging your account for cheating, or worst case, getting it banned.  
-I&#39;m not certain how Ninja Kiwi could enforce this in single player environment, though. But if you&#39;re concerned,
+I&#39;m not certain how they could enforce this in single player environment, though. But if you&#39;re concerned,
 you can always run the bot offline. <u>You have been warned</u>.***
 
 
@@ -93,14 +96,14 @@ adding new content.
 
 # <u>Installation</u>
 First you need to install [Python](https://www.python.org/downloads/).  
-Most of bot functions were programmed in Python versions 3.12 and 3.13 so **Python 3.12+** is recommended.  
-It is likely to work on some earlier versions of Python 3, but this has not been tested.
+Most of bot was programmed in Python versions 3.12 and 3.13 so **Python 3.12+** is recommended.  
+It is likely to work on earlier versions of Python 3, but this has not been tested.
 
 Now, download *BTD6bot*:
 
 Click the green [<> Code] button at the top of github page.
 
-![](docs/github/images/github_codebutton.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/github_codebutton.PNG)
 
 Then either
 
@@ -121,7 +124,8 @@ Next, the external dependencies. Install the following third party packages:
 
 Install them by going to your BTD6bot folder, then run ``reqs.bat``. 
 
-If this isn&#39;t working: run cmd, change your current directory to where you installed BTD6bot, then type
+If this isn&#39;t working: run cmd, change your current directory to ``<your path>/btd6bot`` where you installed
+BTD6bot, then type
 ``
 pip install -r requirements.txt
 ``
@@ -132,11 +136,11 @@ above 1.7.8 cause a fatal error when any gui hotkeys are used.
 And that&#39;s it! You&#39;re good to go and should be able to start BTD6bot. To test this, try one of the following:
 
 - Open your BTD6bot folder, then run the ``run.bat`` file
-- Open cmd, set current directory to BTD6bot install folder, then type ``py btd6bot ``
+- Open cmd, set current directory to ``<your path>/btd6bot`` then type ``py btd6bot ``
 
 
 # <u>First-time setup</u>
-| ![](docs/github/images/main/main.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/main/main.PNG) |
 |:--:|
 | *Main window default view*|
 
@@ -162,39 +166,46 @@ should something break irrevocably.**
 ## Quick tutorial:
 
 *1920x1080 monitor is used below; your values can look different*  
-*1600x900 is used as custom resolution* 
+*1600x900 is used as custom resolution example* 
 
 1. Set hotkeys in **Set hotkeys** window; gui hotkeys are not mandatory, but very much recommended. After you&#39;re
 done, close hotkeys window.
 2. Open **Settings** window and set resolution. 
 
-    **Select a resolution with aspect ratio of 16:9, or one that can be reduced to 16:9 by using windowed mode.
-    For latter, read [this](#using-windowed-mode-for-resolutions-with-varying-aspect-ratios)**. 
+    **Select a resolution with aspect ratio of 16:9 AND prefer fullscreen**.
 
-    - If you use fullscreen/windowed fullscreen, **don&#39;t** enable custom resolution.
+    *However, it might be possible to use larger aspect ratios if you use fullscreen in-game, but set bot to use custom resolution and windowed mode in order to limit the area the bot sees; check [this](#using-windowed-mode-for-resolutions-with-varying-aspect-ratios) for more info*. 
 
-        ![](docs/github/images/settings/disable_custom.PNG)
+    - If you use fullscreen/windowed fullscreen, **don&#39;t** enable custom resolution, or use windowed mode. Just leave it untoggled.
+
+        ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/disable_custom.PNG)
 
     - If you use custom resolution, set width & height values, then update values.
-        - Toggle windowed mode on if you wish to use it. It&#39;s recommended to use fullscreen, though.
+        - Toggle windowed mode on if you wish to use it. **It&#39;s recommended to always use fullscreen**, and use
+        windowed mode only for *aspect ratios differing from 16:9*, as mentioned before.
 
-        **If windowed mode is enabled, run BTD6 with ``-popupwindow`` launch argument.**
+        ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/custom_windowed.PNG)
 
-        ![](docs/github/images/settings/custom_windowed.PNG)
+        **If windowed mode is enabled, you must run Btd6 with ``-popupwindow`` launch argument.** E.g. if you use Steam
+        version:  
+        library -> bloons td 6 -> right-click -> properties, then set the following
+
+        ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/launchoption.PNG)
+
 
 3. Enable ocr auto-adjusting, make sure it has correct res and win values. Res is your current resolution, win stands
 for fullscreen (``win=0``) or windowed (``win=1``).  
 Finally, ``monkeys=all`` and ``delta=4`` values should be automatically set.  
 Easiest way is to just press ``Reset args`` button once, then press ``Set args`` button after.
 
-    ![](docs/github/images/settings/auto_adjust.PNG)
+    ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/auto_adjust.PNG)
 
-    Now, close settings window. In main window, press **Initialize bot**, then **Open bot window** to open monitoring
-    window.
+    Now, close settings window. In main window, press **Initialize bot**, wait a bit for initialization, then press
+    **Open bot window** to open monitoring window.
     
-    Have your BTD6 game opened on main
-    monitor, placed in main menu screen. Now, run the bot and let it finish auto-adjusting. This process can take a 
-    while.  
+    Have your Btd6 game opened on main
+    monitor, placed in main menu screen with ``Play`` button visible. Now, run the bot and let it finish auto-adjusting.
+    This process can take a while.  
     After adjusting process is finished, bot should be able to detect in-game upgrade texts properly based on your
     current resolution settings.
 
@@ -220,7 +231,7 @@ Click the gear symbol and open hotkeys menu.
 
 Now, update your game hotkeys for bot. Press &#39;Set hotkeys&#39; button in gui. Following window opens:
 
-| ![](docs/github/images/hotkeys/hotkeys.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/hotkeys/hotkeys.PNG) |
 |:--:|
 | *Hotkey window*|
 
@@ -259,7 +270,7 @@ After you&#39;ve updated all the keys, close the hotkey window.
 
 Next, open settings window by pressing &#39;Settings&#39; button.
 
-| ![](docs/github/images/settings/settings.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/settings.PNG) |
 |:--:|
 | *Settings window*|
 
@@ -289,7 +300,7 @@ option off, you should see your current resolution next to &#39;Current resoluti
 
     For example, if your monitor is ``1920x1080``, you see following 
 
-    ![](docs/github/images/settings/disable_custom.PNG)
+    ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/disable_custom.PNG)
 
     [**Note**] For bot, fullscreen and windowed fullscreen mean the same thing so always use this option if you wish to
     use maximum supported resolution.
@@ -301,18 +312,18 @@ Custom value is stored in a file and will be loaded back if you disable and re-e
     Example: if you have ``1920x1080`` as native res and set a custom res ``1600x900``, then toggling setting on and off
     would display following resolutions:
 
-    ![](docs/github/images/settings/difference.PNG)
+    ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/difference.PNG)
 
     With custom resolutions, you can enable *windowed mode*.
     
-    ![](docs/github/images/settings/windowed.PNG)
+    ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/windowed.PNG)
     
     If you use windowed mode in btd6 normally, it adds the bar on top of game window. Bot, however, assumes this bar
     doesn&#39;t exist and requires game to be opened with ``-popupwindow`` option.  
     If you have Btd6 steam version, go to steam library, right click on Bloons TD 6, then simply add the argument like
     shown below
 
-    ![](docs/github/images/settings/launchoption.PNG)
+    ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/launchoption.PNG)
 
     Using windowed mode can decrease the text quality for ocr, though. If you use significantly smaller resolution with
     windowed mode, bot could have issues with verifying text inputs.  
@@ -321,7 +332,7 @@ Custom value is stored in a file and will be loaded back if you disable and re-e
 Lastly, enable the &#39;Auto-adjust ocr upgrade data the next time a plan is run&#39; option. 
 For 1920x1080 with fullscreen enabled, it looks like this:
 
-![](docs/github/images/settings/auto_adjust.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/auto_adjust.PNG)
 
 
 It should include following parts, each separated by space:
@@ -342,11 +353,11 @@ Then just press &#39;Set args&#39; and you&#39;re done! You may now close the se
 For last part, you need to enter the monitoring window. Click the &#39;Initialize bot&#39; button, located at bottom
 right of main window:
 
-![](docs/github/images/main/init_button.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/main/init_button.PNG)
 
 Following load message appears
 
-![](docs/github/images/main/load_msg.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/main/load_msg.PNG)
 
 Program needs to load the ocr model into your temporary memory (RAM) each time you initialize bot and is therefor only
 required once per runtime loop. If you close the entire program and reopen it, the model must be loaded again.
@@ -354,11 +365,11 @@ required once per runtime loop. If you close the entire program and reopen it, t
 After the message disappears, model has been loaded and initialize button should now display &#39;Open bot window&#39;
 instead.
 
-![](docs/github/images/main/openbotwin_button.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/main/openbotwin_button.PNG)
 
 Click the button to open monitoring window.
 
-| ![](docs/github/images/monitoring/monitoring.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/monitoring/monitoring.PNG) |
 |:--:|
 | *Monitoring window*|
 
@@ -439,7 +450,7 @@ project:
 
 ---
 
-| ![](docs/github/images/monitoring/monitoring_adjustbegin.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/monitoring/monitoring_adjustbegin.PNG) |
 |:--:|
 | *After 'Run' button is pressed and menu play button is detected on main monitor, bot sets a countdown from 5 to 0, then begins the auto-adjusting process*|
 
@@ -458,9 +469,9 @@ adjusting may begin.
  2. goes over all the upgrades of listed monkeys, read their upgrade texts, check how closely they match to actual
     texts and save the obtained delta value. Because monkeys=all, it checks all monkeys.
  3. after it checks all listed monkeys once, it will check them again! This time it places them on opposite side of map.
-    Why? Well, if you&#39;re never noticed, depending on which side of middle section you place a monkey (left or right),
-    the monkey panel opens on the opposite side of screen. Different sides can produce slighly different inputs so bot
-    will analyze both sides and save all the deltas.
+    Why? Well, if you&#39;re never noticed, depending on which side of middle section you place a monkey 
+    (left or right), the monkey panel opens on the opposite side of screen. Different sides can produce slighly
+    different inputs so bot will analyze both sides and save all the deltas.
  4. After both sides are checked, both compares deltas of left and right side, selects the smaller value and save it as
     final delta.
  5. To finish things, all delta values are adjusted with equal amount. Default value is 4 i.e. delta=4: this adjust
@@ -472,7 +483,7 @@ adjusting may begin.
     manually.
 
 
-| ![](docs/github/images/monitoring/monitoring_adjustend.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/monitoring/monitoring_adjustend.PNG) |
 |:--:|
 | *Adjusting process complete*|
 
@@ -482,11 +493,11 @@ your bot is ready to run!
 To run your first plan, it&#39;s recommended to pick something simple. Close the monitoring window and select either
 ``[monkey meadow, easy-standard]`` or ``[dark castle, easy-standard]`` in main window:
 
-![](docs/github/images/main/monkeymeadow.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/main/monkeymeadow.PNG)
 
 or
 
-![](docs/github/images/main/darkcastle.PNG)
+![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/main/darkcastle.PNG)
 
 Make sure you have the required hero, all monkeys and their upgrade paths unlocked. For upgrade paths:
 
@@ -517,7 +528,7 @@ doing
 
 ## Main
 
-| ![](docs/github/images/main/main_modified.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/main/main_modified.PNG) |
 |:--:|
 | *Main window, with ocr already initialized. Currently selected plan is bloody_puddlesHardChimps, collection event and replay modes enabled.*|
 
@@ -560,7 +571,7 @@ i.e. selected map + strategy combination. Info is stored in each plan file and c
 
 ## Help
 
-| ![](docs/github/images/help/help.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/help/help.PNG) |
 |:--:|
 | *Help window, expanded to fullscreen. It displays the same README.md contents, but links don&#39;t work*|
 
@@ -570,7 +581,8 @@ version. However, it should have exact same contents as web version so you can u
 
 - It has dark mode always enabled.
 
-- Comes with one major issue: **none of the links work**. Reference links simply point nowhere in document, web links display some random mess so don&#39;t try to use them either.
+- Comes with one major issue: **none of the links work**. Reference links simply point nowhere in document, web links
+display some random mess so don&#39;t try to use them either.
 
 Also something worth to mention: the offline readme is actually an html document translated from the README markdown
 file. Annoyingly, the Python library used for this conversion requires absolutely file paths in order to display all
@@ -584,7 +596,7 @@ or reopening the Main window, this file gets deleted again!
 
 ## Queue
 
-| ![](docs/github/images/queue/queue.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/queue/queue.PNG) |
 |:--:|
 | *Queue window with dark_dungeonsHardChimps plan inserted in queue. When a plan is selected, its info panel is displayed.*|
 
@@ -597,7 +609,7 @@ hotkeys: 'a' for add, 'r' for remove.
 
 ## Hotkeys
 
-| ![](docs/github/images/hotkeys/hotkeys.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/hotkeys/hotkeys.PNG) |
 |:--:|
 | *Hotkey window.*|
 
@@ -617,7 +629,7 @@ hotkeys: 'a' for add, 'r' for remove.
 
 ## Settings
 
-| ![](docs/github/images/settings/settings.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/settings.PNG) |
 |:--:|
 | *Settings window*|
 
@@ -631,30 +643,33 @@ which was already used in [First-time setup](#first-time-setup).
     Change resolution the bot uses to determine relative mouse clicking/ocr text locations. Must match with used in-game
     resolution which should approximately have 16:9 aspect ratio.
 - **Windowed mode**: 
-    If Btd6 is run in windowed mode. Btd6 must be launced with -popupwindow lauch option and window cannot be moved from
-    its initial position. 
+    If Btd6 is run in windowed mode. Btd6 must be launced with ``-popupwindow`` launch option and window cannot be moved
+    from its initial position. 
     
     Windowed mode can face issues with ocr accuracy, though. If resolution is considerably smaller, text reading errors
     become more common and can hinder upgrading of monkeys.
 
+    Therefore, **it&#39;s always recommended you use fullscreen if possible.**
+
     #### <u>*Using windowed mode for resolutions with varying aspect ratios*</u>
-    As stated under &#39;Enable custom resolution&#39;, resolutions should have aspect ratios of 16:9 or very close to
-    it.
+    As stated under &#39;Enable custom resolution&#39;, resolutions should have aspect ratio of 16:9. But, it is possible to leave in-game resolution to your native resolution, but still use custom resolution + windowed mode to reduce the actual screen area.
 
     Because windowed mode normally leaves empty space around, you could limit the readable area to the middle of screen.
-    A good example would be 3440x1440 resolution: it adds extra borders during maps which is 440 pixels each side. This
-    means the actual screen area is 3440-440*2=2560 which has aspect ratio of 16:9 with height of 1440! In fact, this
-    should also work for menu screens because play and hero select button are in correct position relative to everything
-    else.
+    A good example would be ``3440x1440`` resolution: it adds extra borders during maps which is 440 pixels each side. This
+    means the actual screen area is 3440-440*2=2560 which has aspect ratio of 16:9 with height of 1440!  
+    In fact, this should also work for menu screens because play and hero select button are in correct position relative
+    to everything else. Only actually problematic case would be the map search button which falls outside the middle
+    area, but there&#39;s a built-in checking system which should be able to locate this button no matter the resolution
+    setting.  
     So if you have a 3440x1440 monitor and wish to play on this resolution, go to gui settings:
 
-    - enable custom resolution and set it as 2560x1440
+    - enable custom resolution and set it as ``2560x1440``
     - enable windowed mode
     - And of course, remember to readjust ocr deltas for new resolution, as always!
 
     Here's a beautiful visual explanation:
 
-    ![](docs/github/images/settings/3440x1440example.png)
+    ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/settings/3440x1440example.png)
     
     
     In general, for any resolution, check the following:
@@ -668,7 +683,7 @@ which was already used in [First-time setup](#first-time-setup).
     - (optional) if required, you could repeat this for y-resolution as well, but I believe it&#39;s very rare you&#39;d
     need this. One example would be 1280x800 - test this in-game and see how it adds a wider bar on top and bottom of
     the screen.
-    - Then readjust ocr values and you&#39;re good to go.
+    - Then readjust ocr values like usual and you should be good to go.
 
 
 - **Game version**: 
@@ -736,7 +751,7 @@ on trying, these texts must be as precisely readable as possible. For upgrades, 
 
 ## Monitoring
 
-| ![](docs/github/images/monitoring/monitoring.PNG) |
+| ![](file:/c:/Hobbies/IT/Programming/Python/Projects/btd6bot/btd6bot/Files/helpwindow/images/monitoring/monitoring.PNG) |
 |:--:|
 | *Monitoring window, with plan dark_castleEasyStandard selected, no extra modes enabled.*|
 

--- a/btd6bot/bot/commands/monkey.py
+++ b/btd6bot/bot/commands/monkey.py
@@ -791,6 +791,21 @@ class Monkey(_MonkeyConstants):
         if cpos_x is not None:
             self._pos_y = cpos_y
         kb_mouse.click((self._pos_x, self._pos_y))
+        counter = 0
+        if self._panel_pos == 'right':
+            while not ocr.strong_delta_check('Sell', Monkey._RIGHT_PANEL_SELL_LOCATION, OCR_READER):
+                if counter == 3:
+                    kb_mouse.click((self._pos_x, self._pos_y))
+                    counter = 0
+                time.sleep(0.1)
+                counter += 1
+        elif self._panel_pos == 'left':
+            while not ocr.strong_delta_check('Sell', Monkey._LEFT_PANEL_SELL_LOCATION, OCR_READER):
+                if counter == 3:
+                    kb_mouse.click((self._pos_x, self._pos_y))
+                    counter = 0
+                time.sleep(0.1)
+                counter += 1
         if cpos_x is not None:
             self._update_panel_position(cpos_x)
         for upg in upgrade_list:

--- a/btd6bot/bot/kb_mouse.py
+++ b/btd6bot/bot/kb_mouse.py
@@ -37,11 +37,13 @@ class ScreenRes:
         ScreenRes.width, ScreenRes.height = ScreenRes.BASE_RES
 
 
-def pixel_position(xy: tuple[float | None, float | None]) -> tuple[int, int]:
+def pixel_position(xy: tuple[float | None, float | None], ignore_windowed: bool = False) -> tuple[int, int]:
     """Reverts coordinate scalars back to pixel coordinates of user's display resolution.
 
     Args:
         xy: Scalar coordinates as a tuple.
+        ignore_windowed: Ignores windowed mode coordinate scaling. Default is False. Currently only use case for True is
+            to click map search bar top left if ultrawide resolution is used.
         
     Returns:
         Pixel coordinates as a tuple. If scalar coordinates are not floats, return (-1, -1).
@@ -49,7 +51,9 @@ def pixel_position(xy: tuple[float | None, float | None]) -> tuple[int, int]:
     if (isinstance(xy[0], float) or isinstance(xy[0], int)) and (isinstance(xy[1], float) or isinstance(xy[1], int)):
         x: int
         y: int
-        if BotVars.windowed:
+        if ignore_windowed:
+            x, y = round(ScreenRes.BASE_RES[0]*xy[0]), round(ScreenRes.BASE_RES[1]*xy[1])
+        elif BotVars.windowed:
             x = round(ScreenRes.width*xy[0] + (ScreenRes.BASE_RES[0] - ScreenRes.width)/2)
             y = round(ScreenRes.height*xy[1] + (ScreenRes.BASE_RES[1] - ScreenRes.height)/2)
         else:
@@ -58,18 +62,20 @@ def pixel_position(xy: tuple[float | None, float | None]) -> tuple[int, int]:
     print('Error with converting scalars to pixels.')
     return -1, -1   # this was added to satisfy mypy type hints.
 
-def click(pos: tuple[float | None, float | None], clicks: int=1) -> None:
+def click(pos: tuple[float | None, float | None], clicks: int=1, ignore_windowed: bool = False) -> None:
     """Left-clicks mouse at a desired coordinate. Converts scalar coordinates to pixel coordinates to find position.
 
     Args:
         pos: Mouse position, in scalar coordinates.
         clicks: Amount of clicks performed. Default value is 1.
+        ignore_windowed: Ignores windowed mode coordinate scaling. Default is False. Currently only use case for True is
+            to click map search bar top left if ultrawide resolution is used.
     """
     if isinstance(clicks, int) and clicks >= 1:
         for _ in range(clicks):
             time.sleep(0.1)
             old_X, old_Y = pyautogui.position()
-            new_X, new_Y = pixel_position((pos[0], pos[1]))
+            new_X, new_Y = pixel_position((pos[0], pos[1]), ignore_windowed)
             pyautogui.moveTo(new_X, new_Y)
             pyautogui.click(new_X, new_Y)
             pyautogui.moveTo(old_X, old_Y)

--- a/btd6bot/bot/rounds.py
+++ b/btd6bot/bot/rounds.py
@@ -200,6 +200,12 @@ class Rounds:
         Returns:
             Current round number.
         """
+        if prev_round == -1:
+            print("Map selection failed.")
+            kb_mouse.click((0.1911458333333, 0.0388888888889))
+            time.sleep(1)
+            kb_mouse.press_esc()
+            return Rounds.end_round + 1
         current_round: int
         if Rounds.defeat_status:
             BotData.set_data(current_round=Rounds.end_round+1)

--- a/btd6bot/gui/settings_window.py
+++ b/btd6bot/gui/settings_window.py
@@ -83,7 +83,7 @@ class SettingsWindow:
         resolution_current_value.grid(column=3, columnspan=2, row=1, sticky='sw', padx=(1,35), pady=(1,10))
         res_reminder = tk.Text(self.settings_window, wrap=tk.WORD, width=10, height=5, relief='sunken')
         res_reminder.grid(column=4, row=1, rowspan=3, sticky='nw', padx=1, pady=(1,10))
-        res_reminder.insert("end", '[Reminder] Aspect ratio should be ~16:9')
+        res_reminder.insert("end", '[Reminder] Aspect ratio should be 16:9')
         res_reminder['state'] = 'disabled'
 
         self.resolution_width_entry = tk.Entry(self.settings_window, width=10)

--- a/btd6bot/plans/infernalHardChimps.py
+++ b/btd6bot/plans/infernalHardChimps.py
@@ -37,8 +37,7 @@ def play(rounds: tuple[str, str, str, int, int, str]) -> None:
             ability(1,4.5)
         elif current_round == 16:
             heli = Monkey('heli', 0.8151041666667, 0.512037037037)    
-            heli.target('lock')
-            heli.special(1, 0.4411458333333, 0.5527777777778)
+            heli.target('lock', 0.4411458333333, 0.5527777777778)
         elif current_round == 20:
             heli.upgrade(['1-0-0'])
         elif current_round == 21:
@@ -83,7 +82,7 @@ def play(rounds: tuple[str, str, str, int, int, str]) -> None:
             dart.upgrade(['0-0-1','0-0-2'])
         elif current_round == 96:
             alch2 = Monkey('alch', 0.4536458333333, 0.6981481481481)
-            alch2.upgrade(['1-0-0','2-0-0','3-0-0','4-0-0','3-1-0','3-2-0'])
+            alch2.upgrade(['1-0-0','2-0-0','3-0-0','4-0-0','4-1-0','3-2-0'])
             hero.target('strong')
         elif current_round == 97:
             mermonkey = Monkey('mermonkey', 0.4359375, 0.3518518518519)

--- a/btd6bot/plans/infernalHardChimps.py
+++ b/btd6bot/plans/infernalHardChimps.py
@@ -82,7 +82,7 @@ def play(rounds: tuple[str, str, str, int, int, str]) -> None:
             dart.upgrade(['0-0-1','0-0-2'])
         elif current_round == 96:
             alch2 = Monkey('alch', 0.4536458333333, 0.6981481481481)
-            alch2.upgrade(['1-0-0','2-0-0','3-0-0','4-0-0','4-1-0','3-2-0'])
+            alch2.upgrade(['1-0-0','2-0-0','3-0-0','4-0-0','4-1-0','4-2-0'])
             hero.target('strong')
         elif current_round == 97:
             mermonkey = Monkey('mermonkey', 0.4359375, 0.3518518518519)

--- a/btd6bot/plans/quadHardChimps.py
+++ b/btd6bot/plans/quadHardChimps.py
@@ -214,6 +214,8 @@ def play(rounds: tuple[str, str, str, int, int, str]) -> None:
             bomb.upgrade(['0-1-0', '0-2-0', '0-3-0'])
             bomb.target('strong')
         elif current_round == 100:
+            druid = Monkey('druid', 0.3807291666667, 0.2796296296296)
+            druid.upgrade(['0-0-1','0-0-2','0-0-3'])
             heli.special(1, 0.6057291666667, 0.3527777777778)
             ability(1, 6)
             ability(2, 7.5)


### PR DESCRIPTION
Upgrading a monkey/hero will now perform similar check as placing one. Bot would rarely click the upgrade panel away (not sure what interraction caused this) and leave bot to search for upgrade path message when the actual upgrade panel was not even opened. Now, bot will click the monkey location again after a short while if it can't detech the panel ``sell`` message.

To implement above, kb_mouse -> click and pixel_position have a new argument ``ignore_windowed`` which if set on True, ignores windowed resolution scaling and uses native resolution instead. Default value is False.

Other:
- added map search bar detection system. Notably, the button to open search bar lies outside the inner area which could cause
problems with adjusted custom resolutions. Now, if the initial button location fails to open search bar, bot will perform a second check and click the button location on native resolution.
- small adjustment to existing plans
- improve README.md