### PR TITLE
Critical bug fixes and 2 new chimps plans

### DIFF
--- a/btd6bot/bot/commands/monkey.py
+++ b/btd6bot/bot/commands/monkey.py
@@ -901,27 +901,25 @@ class Monkey(_MonkeyConstants):
             kb_mouse.kb_input(hotkeys[button])
             if self._name == 'super' and re.search("^4-[0-2]-0$|^4-0-[0-2]$|^5-[0-2]-0$|^5-0-[0-2]$", upg) != None:
                 kb_mouse.kb_input(Key.enter)    # if upgrade is Sun Temple/True Sun God, press Enter to confirm it
-            start = times.current_time()
-            while (times.current_time()-start < 0.75):
-                if self._panel_pos == 'right':
-                    if ocr.strong_delta_check(
-                        '_upgrade_', 
-                        (current_r[0], current_r[1], current_r[2], current_r[3]),
-                        OCR_READER,
-                        upg_match):
-                        upgraded = 1
-                elif self._panel_pos == 'left':
-                    if ocr.strong_delta_check(
-                        '_upgrade_', 
-                        (current_l[0], current_l[1], current_l[2], current_l[3]),
-                        OCR_READER, 
-                        upg_match):
-                        upgraded = 1
-                if upgraded:
-                    if not OcrValues._log_ocr_deltas:
-                        print('Upgraded.')
-                    self._upgrade_path = upg
-                    return
+            if self._panel_pos == 'right':
+                if ocr.strong_delta_check(
+                    '_upgrade_', 
+                    (current_r[0], current_r[1], current_r[2], current_r[3]),
+                    OCR_READER,
+                    upg_match):
+                    upgraded = 1
+            elif self._panel_pos == 'left':
+                if ocr.strong_delta_check(
+                    '_upgrade_', 
+                    (current_l[0], current_l[1], current_l[2], current_l[3]),
+                    OCR_READER, 
+                    upg_match):
+                    upgraded = 1
+            if upgraded:
+                if not OcrValues._log_ocr_deltas:
+                    print('Upgraded.')
+                self._upgrade_path = upg
+                return
 
     def _place(self) -> None:
         """Places a monkey to an in-game location.

--- a/btd6bot/bot/commands/monkey.py
+++ b/btd6bot/bot/commands/monkey.py
@@ -791,11 +791,15 @@ class Monkey(_MonkeyConstants):
         if cpos_x is not None:
             self._pos_y = cpos_y
         kb_mouse.click((self._pos_x, self._pos_y))
+        if cpos_x is not None:
+            self._update_panel_position(cpos_x)
         counter = 0
         if self._panel_pos == 'right':
             while not ocr.strong_delta_check('Sell', Monkey._RIGHT_PANEL_SELL_LOCATION, OCR_READER):
                 if counter == 3:
                     kb_mouse.click((self._pos_x, self._pos_y))
+                    if cpos_x is not None:
+                        self._update_panel_position(cpos_x)
                     counter = 0
                 time.sleep(0.1)
                 counter += 1
@@ -803,11 +807,11 @@ class Monkey(_MonkeyConstants):
             while not ocr.strong_delta_check('Sell', Monkey._LEFT_PANEL_SELL_LOCATION, OCR_READER):
                 if counter == 3:
                     kb_mouse.click((self._pos_x, self._pos_y))
+                    if cpos_x is not None:
+                        self._update_panel_position(cpos_x)
                     counter = 0
                 time.sleep(0.1)
                 counter += 1
-        if cpos_x is not None:
-            self._update_panel_position(cpos_x)
         for upg in upgrade_list:
             u = self._upgrade_path
             print(f'Upgrading {u} {self._name.capitalize()} to {upg}...', end=' ')

--- a/btd6bot/bot/menu_start.py
+++ b/btd6bot/bot/menu_start.py
@@ -231,12 +231,13 @@ def _update_external_variables(begin_r: int, end_r: int) -> None:
         begin_r: First round.
         end_r: Final round.
     """
+    OcrValues._log_ocr_deltas = False
     bot.hotkeys.hotkeys = bot.hotkeys.generate_hotkeys()
     Rounds.begin_round, Rounds.end_round = begin_r, end_r
     Rounds.defeat_status = False
     AutoStart.called_forward = False
     PauseControl.pause_length = 0
-    BotVars.paused = False
+    BotVars.paused = False 
     _reset_global_targeting()
     try:
         with open(pathlib.Path(__file__).parent.parent/'Files'/'gui_vars.json') as f:

--- a/btd6bot/plans/erosionHardChimps.py
+++ b/btd6bot/plans/erosionHardChimps.py
@@ -1,0 +1,131 @@
+"""
+[Hero] Psi
+[Monkey Knowledge] -
+-------------------------------------------------------------
+===Monkeys & upgrades required===
+dart 0-0-1
+bomb 5-2-0
+glue 0-1-3
+
+sniper 1-2-5
+sub 2-0-2
+
+ninja 0-0-0
+alch 4-2-0
+druid 3-0-2
+
+spike 0-4-2
+village 2-4-2
+_______________________________________
+Gameplay-wise, should be viable for black bordering.
+
+For late game rounds (90+), bot might skip ahead and begin executing commands for upcoming rounds.
+This should not matter, as long as 99 => 100 is detected normally; 100 requires abilities and if bot uses them earlier than intended, you will lose.
+"""
+
+from._plan_imports import *
+
+def play(rounds: tuple[str, str, str, int, int, str]) -> None:
+    BEGIN, END = menu_start.load(*rounds)
+    current_round = BEGIN-1
+    map_start = time()
+    while current_round < END+1:
+        current_round = Rounds.round_check(current_round, map_start)
+        if current_round == BEGIN:
+            sub1 = Monkey('sub', 0.2177083333333, 0.8157407407407)
+            dart1 = Monkey('dart', 0.1911458333333, 0.5555555555556)
+            forward()
+            dart1.upgrade(['0-0-1'])
+        elif current_round == 9:
+            sub1.upgrade(['0-0-1'])
+        elif current_round == 13:
+            sub1.upgrade(['0-0-2'])
+        elif current_round == 18:
+            hero = Hero(0.6489583333333, 0.0601851851852)
+            sub1.upgrade(['1-0-2'])
+        elif current_round == 21:
+            sub1.upgrade(['2-0-2'])
+        elif current_round == 25:
+            sniper1 = Monkey('sniper', 0.4729166666667, 0.0435185185185)
+            sniper1.upgrade(['1-0-0'])
+            sniper1.target('strong')
+        elif current_round == 27:
+            bomb = Monkey('bomb', 0.8348958333333, 0.312037037037)
+            sniper2 = Monkey('sniper', 0.8380208333333, 0.2546296296296)
+            sniper2.upgrade(['0-1-0','0-2-0'])
+        elif current_round == 30:
+            sniper2.upgrade(['0-2-1'])
+        elif current_round == 31:
+            sniper2.upgrade(['0-2-2'])
+        elif current_round == 35:
+            sniper2.upgrade(['0-2-3'])
+            hero.target('strong')
+        elif current_round == 36:
+            ninja = Monkey('ninja', 0.1723958333333, 0.2564814814815)
+        elif current_round == 39:
+            sniper2.upgrade(['0-2-4'])
+        elif current_round == 41:
+            alch = Monkey('alch', 0.8369791666667, 0.2027777777778)
+            alch.upgrade(['1-0-0','2-0-0','3-0-0'])
+        elif current_round == 43:
+            alch.upgrade(['3-1-0','3-2-0'])
+        elif current_round == 50:
+            sniper2.upgrade(['0-2-5'])
+        elif current_round == 53:
+            village = Monkey('village', 0.8130208333333, 0.112037037037)
+        elif current_round == 54:
+            village.upgrade(['1-0-0','2-0-0'])
+        elif current_round == 57:
+            bomb.upgrade(['1-0-0','2-0-0','3-0-0','4-0-0','4-1-0','4-2-0'])
+        elif current_round == 58:
+            glue = Monkey('glue', 0.7036458333333, 0.112962962963)
+            glue.target('strong')
+        elif current_round == 61:
+            glue.upgrade(['0-0-1','0-0-2','0-0-3','0-1-3'])
+        elif current_round == 62:
+            druid = Monkey('druid', 0.6890625, 0.3842592592593)
+            druid.upgrade(['1-0-0','2-0-0','3-0-0','3-0-1','3-0-2'])
+        elif current_round == 77:
+            alch.upgrade(['4-2-0'])
+        elif current_round == 78:
+            ability(2,3.5)
+        elif current_round == 80:
+            ability(1,5)
+        elif current_round == 81:
+            ability(1,11)
+            ability(2,16)
+        elif current_round == 82:
+            ability(1,12)
+            ability(2,19)
+        elif current_round == 83:
+            ability(1,10)
+        elif current_round == 84:
+            ability(1,8)
+            ability(2,10)
+            bomb.upgrade(['5-2-0'])
+        elif current_round == 86:
+            village.upgrade(['2-1-0','2-2-0'])
+        elif current_round == 89:
+            ability(1,8)
+            village.upgrade(['2-3-0'])
+        elif current_round == 95:
+            village.upgrade(['2-4-0'])
+        elif current_round == 96:
+            spike1 = Monkey('spike', 0.7432291666667, 0.1055555555556)
+            spike1.upgrade(['0-1-0','0-2-0','0-3-0','0-3-1','0-3-2'])
+            spike1.target('smart')
+            ability(2)
+            ability(3)
+            spike1.upgrade(['0-4-2'])
+        elif current_round == 97:
+            spike2 = Monkey('spike', 0.6973958333333, 0.0342592592593)
+            spike2.upgrade(['0-0-1','0-0-2','0-1-2'])
+            ability(3)
+        elif current_round == 98:
+            spike2.upgrade(['0-2-2','0-3-2'])
+        elif current_round == 99:
+            spike2.upgrade(['0-4-2'])
+        elif current_round == 100:
+            ability(3,2)
+            ability(4,3)
+            ability(4,4)            

--- a/btd6bot/plans/gearedHardChimps.py
+++ b/btd6bot/plans/gearedHardChimps.py
@@ -1,0 +1,231 @@
+"""
+[Hero] Rosalia
+[Monkey Knowledge] -
+-------------------------------------------------------------
+===Monkeys & upgrades required===
+dart 0-0-0
+
+sniper 1-3-2
+heli 5-0-5
+
+ninja 0-4-0
+alch 3-2-0
+
+village 2-4-2
+_______________________________________
+"""
+
+from._plan_imports import *
+
+def play(rounds: tuple[str, str, str, int, int, str]) -> None:
+    BEGIN, END = menu_start.load(*rounds)
+    current_round = BEGIN-1
+    map_start = time()
+    while current_round < END+1:
+        current_round = Rounds.round_check(current_round, map_start)
+        if current_round == BEGIN:
+            change_autostart()
+            dart1 = Monkey('dart', 0.1833333333333, 0.5722222222222)
+            sniper1 = Monkey('sniper', 0.2854166666667, 0.5796296296296)
+            sniper1.target('strong')
+            forward()
+            end_round(13)
+        elif current_round == 7:
+            dart2 = Monkey('dart', 0.1838541666667, 0.5685185185185)
+            end_round(12)
+        elif current_round == 8:
+            wait(15)
+            sniper2 = Monkey('sniper', 0.5776041666667, 0.3611111111111)
+            sniper2.target('strong')
+            end_round()
+        elif current_round == 9:
+            end_round(11)
+        elif current_round == 10:
+            dart3 = Monkey('dart', 0.1822916666667, 0.5703703703704)
+            end_round(16)
+        elif current_round == 11:
+            wait(13)
+            sniper3 = Monkey('sniper', 0.5494791666667, 0.7546296296296)
+            sniper3.target('strong')
+            end_round()
+        elif current_round == 12:
+            change_autostart()
+        elif current_round == 13:
+            wait(2)
+            sniper4 = Monkey('sniper', 0.43125, 0.8916666666667)
+        elif current_round == 15:
+            wait(2)
+            sniper5 = Monkey('sniper', 0.54375, 0.7509259259259)
+        elif current_round == 17:
+            change_autostart()
+            end_round(6)
+        elif current_round == 18:
+            hero = Hero(0.4395833333333, 0.9361111111111)
+            wait(8)
+            hero.special(2, x=0.1864583333333, y=0.6175925925926, cpos_x=0.2677083333333, cpos_y=0.8324074074074)
+            hero.special(1)
+            end_round(3)
+        elif current_round == 19:
+            wait(10)
+            sniper1.upgrade(['1-0-0'], cpos_x=0.4380208333333, cpos_y=0.8)
+            end_round()
+        elif current_round == 20:
+            wait(7)
+            hero.special(2, x=0.1890625, y=0.5611111111111, cpos_x=0.2697916666667, cpos_y=0.3194444444444)
+            end_round(3)
+        elif current_round == 21:
+            end_round(8)
+        elif current_round == 22:
+            ability(1,1)
+            wait(7)
+            sniper5.upgrade(['0-1-0','0-2-0'], cpos_x=0.5427083333333, cpos_y=0.7388888888889)
+            end_round()
+        elif current_round == 23:
+            end_round(6)
+        elif current_round == 24:
+            wait(8)
+            sniper5.upgrade(['0-2-1'], cpos_x=0.3260416666667, cpos_y=0.7407407407407)
+            end_round()
+        elif current_round == 25:
+            end_round(10)
+        elif current_round == 26:
+            sniper5.upgrade(['0-2-2'], cpos_x=0.2822916666667, cpos_y=0.5759259259259)
+            wait(9)
+            hero.special(2, x=0.1895833333333, y=0.6138888888889, cpos_x=0.2729166666667, cpos_y=0.8305555555556)
+            end_round(3)
+        elif current_round == 27:
+            end_round(15)
+        elif current_round == 28:
+            wait(7)
+            hero.special(2, x=0.1859375, y=0.5472222222222, cpos_x=0.2697916666667, cpos_y=0.3342592592593)
+            end_round(3)
+        elif current_round == 29:
+            end_round(6)
+        elif current_round == 30:
+            end_round(12)
+        elif current_round == 31:
+            wait(2)
+            sniper5.upgrade(['0-3-2'], cpos_x=0.5421875, cpos_y=0.7462962962963)
+            end_round(5)
+        elif current_round == 32:
+            end_round(11)
+        elif current_round == 33:
+            end_round(13)
+        elif current_round == 34:
+            wait(15)
+            hero.special(2, x=0.1869791666667, y=0.6222222222222, cpos_x=0.2703125, cpos_y=0.8296296296296)
+            heli1 = Monkey('heli', 0.4348958333333, 0.837962962963)
+            heli1.target('lock')
+            heli1.special(1, 0.1354166666667, 0.5527777777778)
+            end_round(3)
+        elif current_round == 35:
+            heli1.upgrade(['1-0-0','2-0-0'], cpos_x=0.4385416666667, cpos_y=0.8101851851852)
+            end_round(6)
+        elif current_round == 36:
+            wait(11)
+            hero.special(2, x=0.1848958333333, y=0.5564814814815, cpos_x=0.2723958333333, cpos_y=0.3398148148148)
+            end_round(3)
+        elif current_round == 37:
+            end_round(17)
+        elif current_round == 38:
+            end_round(14)
+        elif current_round == 39:
+            wait(18)
+            village1 = Monkey('village', 0.59375, 0.5564814814815)
+            village1.upgrade(['0-0-1','0-0-2'])
+            heli1.upgrade(['2-0-1','2-0-2','2-0-3'], cpos_x=0.5520833333333, cpos_y=0.3990740740741)
+            end_round()
+        elif current_round == 40:
+            ability(1,3)
+            end_round(5)
+        elif current_round == 41:
+            end_round(16)
+        elif current_round == 42:
+            wait(10)
+            village2 = Monkey('village', 0.3447916666667, 0.8657407407407)
+            village2.upgrade(['1-0-0','2-0-0'])
+            end_round()
+        elif current_round == 43:
+            ability(1,1.75)
+            wait(8)
+            hero.special(2, x=0.15, y=0.437962962963, cpos_x=0.203125, cpos_y=0.5638888888889)
+            end_round()
+        elif current_round == 44:
+            wait(12)
+            village2.upgrade(['2-0-1','2-0-2'], cpos_x=0.246875, cpos_y=0.4546296296296)
+            alch1 = Monkey('alch', 0.3552083333333, 0.3898148148148)
+            heli2 = Monkey('heli', 0.34375, 0.2898148148148)
+            end_round()
+        elif current_round == 45:
+            heli2.upgrade(['1-0-0','2-0-0','2-0-1','2-0-2','3-0-2'])
+            end_round(3)
+        elif current_round == 46:
+            end_round(7)
+        elif current_round == 47:
+            ability(1)
+            alch1.upgrade(['1-0-0','2-0-0','3-0-0'], cpos_x=0.559375, cpos_y=0.4657407407407)
+            end_round(8)
+        elif current_round == 48:
+            end_round(20)
+        elif current_round == 49:
+            ability(1,5)
+            wait(16)
+            heli1.upgrade(['2-0-4'], cpos_x=0.5510416666667, cpos_y=0.762037037037)
+            hero.special(1, cpos_x=0.44375, cpos_y=0.9564814814815)
+            hero.target('strong')
+            end_round()
+        elif current_round == 50:
+            village1.upgrade(['0-1-2','0-2-2'], cpos_x=0.4489583333333, cpos_y=0.787962962963)
+            change_autostart()
+        elif current_round == 62:
+            wait(2)
+            heli2.upgrade(['4-0-2'], cpos_x=0.509375, cpos_y=0.2722222222222)
+            alch1.upgrade(['3-1-0','3-2-0'], cpos_x=0.4697916666667, cpos_y=0.3805555555556)
+        elif current_round == 76:
+            ability(1)
+        elif current_round == 78:
+            ability(1,3.5)
+            ability(1,25.5)
+        elif current_round == 80:
+            ability(3,1)
+            ability(1,5)
+        elif current_round == 81:
+            ability(2,2)
+            heli2.upgrade(['5-0-2'], cpos_x=0.521875, cpos_y=0.8731481481481)
+        elif current_round == 82:
+            wait(3)
+            village1.upgrade(['0-3-2'], cpos_x=0.4541666666667, cpos_y=0.8175925925926)
+        elif current_round == 89:
+            ability(1,2)
+            ability(2,5)
+        elif current_round == 92:
+            ability(3,7)
+            ability(1,10)
+        elif current_round == 93:
+            ability(2,1)
+            wait(2)
+            heli1.upgrade(['2-0-5'], cpos_x=0.2682291666667, cpos_y=0.5768518518519)
+        elif current_round == 96:
+            change_autostart()
+            wait(20)
+            village1.upgrade(['0-4-2'], cpos_x=0.5614583333333, cpos_y=0.7268518518519)
+            end_round()
+        elif current_round == 97:
+            wait(13)
+            ninja = Monkey('ninja', 0.5479166666667, 0.9212962962963)
+            ninja.upgrade(['0-1-0','0-2-0','0-3-0'])
+            change_autostart()
+            end_round(2)
+        elif current_round == 98:
+            ability(3)
+            ability(4,2)
+            ability(2,3)
+            ability(1,4)
+            ninja.upgrade(['0-4-0'])
+        elif current_round == 99:
+            ability(5,2)
+        elif current_round == 100:
+            ability(3,4)
+            ability(4,5)
+            ability(1,6)
+            ability(2,7)


### PR DESCRIPTION
Two critical bug fixes:
- if upgrade ocr adjusting is performer/started and stopped midway, internal loggin flag is set to True. This flag removes placement confirmations to speed up adjusting process, but breaks the bot under normal use. Only fix was to restart the program, but now a fix has been issued
- current position updating before upgrading had code in wrong order. For this reason, in maps like geader and sanctuary, bot would get stuck with upgrading after positition change if upgrade panel is on opposite site than initially.

Plans:
- gearedHardChimps
- erosionHardChimps
