### PR TITLE
Fix updating of hotkeys

### DIFF
--- a/btd6bot/bot/hotkeys.py
+++ b/btd6bot/bot/hotkeys.py
@@ -3,6 +3,7 @@
 Pynput docs: https://pynput.readthedocs.io/en/latest/keyboard.html#pynput.keyboard.Key
 """
 
+import copy
 import pathlib
 
 from pynput.keyboard import Key
@@ -40,7 +41,7 @@ PYNPUT_KEYS: dict[str, Key] = {
         }
 """Dictionary of supported pynput special keys."""
 
-def generate_hotkeys() -> dict[str, str | Key]:
+def generate_hotkeys(hotkey_dict: dict[str, str | Key]) -> None:
     """Reads hotkey.txt file from 'text files' folder and saves these to dictionary.
 
     Because this program uses pynput library to handle key presses, it needs to convert special/modifier keys
@@ -67,7 +68,8 @@ def generate_hotkeys() -> dict[str, str | Key]:
             actual_hotkeys.update({key: PYNPUT_KEYS[val]})
         else:
             actual_hotkeys[key] = val
-    return actual_hotkeys
+    hotkey_dict.update(actual_hotkeys)
 
-hotkeys: dict[str, str | Key] = generate_hotkeys()
+hotkeys: dict[str, str | Key] = {}
 """Dictionary of current hotkeys read from a hotkeys.txt file."""
+generate_hotkeys(hotkeys)

--- a/btd6bot/bot/menu_start.py
+++ b/btd6bot/bot/menu_start.py
@@ -232,7 +232,7 @@ def _update_external_variables(begin_r: int, end_r: int) -> None:
         end_r: Final round.
     """
     OcrValues._log_ocr_deltas = False
-    bot.hotkeys.hotkeys = bot.hotkeys.generate_hotkeys()
+    bot.hotkeys.generate_hotkeys(bot.hotkeys.hotkeys)
     Rounds.begin_round, Rounds.end_round = begin_r, end_r
     BotVars.defeat_status = False
     Rounds.exit_type = 'defeat'


### PR DESCRIPTION
Hotkeys did not update before restarting the entire program. This was because of a simple mistake which caused the same initial hotkey dictionary to be loaded again and again.