### PR TITLE
Patch: attempt to fix system-related issues with ocr

### DIFF
--- a/btd6bot/_no_gui.py
+++ b/btd6bot/_no_gui.py
@@ -5,7 +5,9 @@ Cannot change settings or enable game modes, as these are controlled via gui.
 Can play any currently supported plan, though, as bot is entirely separated from gui functionality-wise. 
 """
 
+import json
 import os
+from pathlib import Path
 import signal
 import sys
 
@@ -33,28 +35,43 @@ def run() -> None:
         kb_listener.daemon = True
         kb_listener.start()
 
-    print('===================================\n'
-          '|   Welcome to gui-free BTD6bot   |\n'
-          '===================================\n'
-          '/////////\n'
-          '*This one doesn\'t support collection event/queue/replay modes. It won\'t allow user to\n '
+    INFO_MESSAGE = ('*This version doesn\'t support collection event/queue/replay modes. It won\'t allow user to\n '
           'change settings/hotkeys, but current values from gui are shared, so if you want to\n' 
           'adjust them, do that in gui then run this version after. Also, no pause or reset buttons exist.\n'
           '/////////\n'
           '--Commands--\n'
+          'help = displays this message again\n'
+          'adjust = if ocr adjust setting is enabled, runs adjusting process\n'
           'plans = list all available plans.\n'
           'run plan_name = run the plan plan_name <- replace this with an existing plan name.\n'
           '                  >Note that when you use \'run ...\' command first time after running this script, \n '
           '                   the ocr reader is loaded into memory which might take a bit, just wait.\n'
           '                  >Example: run dark_castleEasyStandard\n'
           'exit = exit program. Alternatively use F11 key: this hotkey works while bot is running, in case you \n'
-          '     need a quick exit.\n'
+          '     need a quick exit.'
           )
+    print('===================================\n'
+          '|   Welcome to gui-free BTD6bot   |\n'
+          '===================================\n'
+          '/////////\n')
+    print(INFO_MESSAGE)
     plans = utils.plan_data.read_plans()
     while 1:
         user_input = input('=>')
         if len(user_input) == 0:
             ...
+        elif user_input.lower() == 'help':
+            print(INFO_MESSAGE)
+        elif user_input.lower() == 'adjust':
+            with open(Path(__file__).parent/'Files'/'gui_vars.json') as f:
+                    gui_vars_dict= json.load(f)
+            if gui_vars_dict["ocr_adjust_deltas"]:
+                print(".-------------------------.\n"
+                "| Ocr adjust mode enabled |\n"
+                ".-------------------------.\n")
+                set_plan.run_delta_adjust()
+            else:
+                print("Auto-adjusting not enabled.")
         elif user_input.lower() == 'plans':
             print('All available plans: \n')
             for p in plans:
@@ -64,12 +81,12 @@ def run() -> None:
                 plan_name = user_input.split()[1]
                 if plan_name in plans:
                     print("Running plan: "+"'"+plan_name+"'.\n" 
-                          "1. if this is your first plan of the session, wait for the ocr reader to initialize\n"
-                          "2. number countdowns don't work in non-gui version so expect their entire result to pop\n" 
-                          "   at random.\n" 
-                          "(reason for above is that all print statements are build around gui version and must "
-                          "have flush=False)\n"
-                          "============================================")
+                            "1. if this is your first plan of the session, wait for the ocr reader to initialize\n"
+                            "2. number countdowns don't work in non-gui version so expect their entire result to "
+                            "pop after the countdown finishes.\n" 
+                            "(reason for above is that all print statements are build around gui version and must "
+                            "have flush=False)\n"
+                            "============================================")
                     set_plan.plan_setup(plan_name)
                 else:
                     print('Plan not found.')

--- a/btd6bot/bot/kb_mouse.py
+++ b/btd6bot/bot/kb_mouse.py
@@ -23,6 +23,7 @@ class ScreenRes:
         width (int, class attribute): Screen width. 
         height (int, class attribute): Screen height.
     """
+    controller: pynput.keyboard.Controller = pynput.keyboard.Controller()
     BASE_RES: tuple[int, int] = pyautogui.size()
     width, height = pyautogui.size()
 
@@ -92,7 +93,9 @@ def move_cursor(xy: tuple[float, float], set_duration: float = 0.0) -> None:
     pyautogui.moveTo(x, y, duration=set_duration)
     time.sleep(0.1)
 
-def kb_input(input: Key | KeyCode | str, times: int = 1) -> None:
+def kb_input(input: Key | KeyCode | str, 
+             times: int = 1, 
+             controller: pynput.keyboard.Controller = ScreenRes.controller) -> None:
     """Simulates pressing a single keyboard input by default.
 
     If same key must be pressed multiple times, change 'times' value.
@@ -102,7 +105,7 @@ def kb_input(input: Key | KeyCode | str, times: int = 1) -> None:
         times: How many times key is pressed. Default value is 1.
     """
     if isinstance(times, int) and times >= 1:
-        keyboard = pynput.keyboard.Controller()
+        keyboard = controller
         if isinstance(input, str) and input.strip("<>") in {f"{num}" for num in range(96, 106)}: # numpad keys
             input_key = int(input.strip("<>"))
             for _ in range(times):

--- a/btd6bot/bot/ocr/ocr_reader.py
+++ b/btd6bot/bot/ocr/ocr_reader.py
@@ -7,5 +7,8 @@ No mypy type hints available for easyocr so either 'Reader' or 'Any' is used wit
 
 import easyocr # type: ignore
 
-OCR_READER: easyocr.Reader = easyocr.Reader(['en'], gpu=False, verbose=False)
-"""Easyocr reader for english language text with gpu support disabled."""
+OCR_READER: easyocr.Reader = easyocr.Reader(['en'], gpu=False, verbose=False, quantize=False)
+"""Easyocr reader for english language text with gpu support disabled.
+
+    On windows platforms, you can set quantize=True to test if it improves ocr accuracy.
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@
 easyocr==1.7.2
 markdown==3.8
 matplotlib==3.10.1
-numpy==2.2.3
+numpy==1.26.4; python_version < 3.13
+numpy==2.2.3; python_version >= 3.13
 pillow==11.1.0
 pyautogui==0.9.54
 pynput==1.7.8


### PR DESCRIPTION
This small patch focuses once again to macOS support. It also adds support for older cpus, but running bot on such systems might make ocr too slow and cause bot to not perform as expected.

---
Currently, macOS systems face an issue with ``tkinter`` and ``pynput`` libraries. Both would like to operate under main thread, which causes bad errors that are hard to trace and fix. Because of these issues, I might create a separate version for macOS systems that uses some other library for keyboard functions - or in general, replace ``pynput`` for all version altogether.

Temporary fix is to use gui-free version of btd6bot on mac systems. This can accessed with ``python3 btd6bot -nogui`` command if your current working directory in terminal is ``<your_path>/btd6bot``. No-gui version also shares settings with normal btd6bot so make any changes in gui and save, then open non-gui version after.

**Other changes**
- add a general pynput.keyboard.Controller in kb_mouse.py so kb_input doesn't need to create a new one any time its called
- add ocr auto-adjust support for non-gui version
- requirements.txt should now install correct version of numpy based on user's Python version