### PR TITLE
[v1.0.1] Add wlroots-based Wayland display support to Linux via 'grim'

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -1,4 +1,4 @@
-# Supported game plans (Last updated 2026-04-20)
+# Supported game plans (Last updated 2026-04-30)
 
 - this list is auto-updated using ``scripts/update_plans.py``
 - all implemented plans are listed. Each game mode includes

--- a/README.md
+++ b/README.md
@@ -75,15 +75,22 @@ Because of limited access to other operating systems than Windows, it's very dif
 all of them. Currently:
 - **Windows (10 or higher) is fully supported and thus recommended.**
 
-- **Linux**: tested partially on
-    - **Linux Mint 22.3 (Xfce)**
-    - **Debian 13.4 (GNOME)**
-    
-    Not all features have been tested, but since main functionalities (gui, kb+mouse automation, ocr) do work, bot 
-    should operate just fine.
+- **Linux**: 
 
-    Linux requires some additional dependencies to make Python, ocr, kb+mouse etc. function properly. These are 
-    documented and explained during installation process
+    Tested on following distros:
+    - **Linux Mint 22.3 (Xfce)**
+    - **Debian 13.4 (GNOME on Xorg)**
+    - **Linux Arch (Wayland with Hyprland)**
+    
+    At least gui, kb+mouse automation, and ocr functions have been tested on these distros which means bot should operate just fine.
+
+    => In general, **bot supports X11 or wlroots-based displays.** If your system has one of these available, you should be able to run the bot even if it's not listed above. How these relate to tested distros:
+    - Linux Mint uses X11
+    - Debian GNOME uses *GNOME Wayland* by default, which is based on KDE. This on itself will not work, but you can easily switch to *GNOME on Xorg* which uses X11
+    - Hyprland uses it's custom *aquamarine* compositor for Wayland which also retains wlroots compatibility.
+    
+    For more info, see [this section](_install/INSTALL.md#linux) of the install guide. It will used as a reference later and explains the X11/Wayland compatibility in more detail.
+
 - **MacOS => Not supported, but could still work** 
 
     Bot functionality remains largely untested without access to modern native Mac system i.e. owning a Mac PC. 
@@ -281,7 +288,7 @@ When you run the install script, it will download the current github main branch
 [**Notes**] 
 - You can move and rename `BTD6bot-main` directory freely, just don't rename any files inside it 
 unless you know what you're doing.
-- for more details such as step-by-step explanation of script code, check [here](_install/INSTALL.md)
+- for more details about what the scripts actually do, check [this](_install/INSTALL#detailed-explanation-of-scripts)
 
 ## Option 2: Manual install
 

--- a/_install/INSTALL.md
+++ b/_install/INSTALL.md
@@ -40,31 +40,54 @@ environments:
 ### Linux
 
 Following observations are based on testing the bot on
-- *Linux Mint 22.3* 
-- *Debian 13.4 GNOME Desktop*
+- *Linux Mint 22.3 Xfce Edition* 
+- *Debian 13.4 + GNOME Desktop*
+- *Linux Arch + Wayland with Hyprland*
 
-========================================
+**Please read all the bullet points below carefully, especially <u>the one explaining display servers</u>**
+
+================================================================
 
 - for Python you need to `sudo apt install` the following:
     - python3
     - python3-pip
     - python3-venv
     - python3-tk
-    - curl 
-        - for auto-downloading btd6bot github repo contents
-    - gnome-screenshot 
-        - to enable image capturing for Python's 'mss' library so that OCR works properly
 
-    You can also specify python version in all python-based installations e.g. python3.13.10
+    You can also specify python version in all python-based installations e.g. python3.13.10. Bot supports currently 
+    versions 3.12-3.14.
 
-- You also need X11 environment to run the bot because OCR (easyocr -> torch) and kb+mouse (pyautogui, pynput) cannot 
-operate on stricter ones such as *Wayland*. 
-    - on some distros, for example Mint, this is the default (at least for now) so no need to do any changes
-    - but if not, for example Debian + GNOME, you can do the following:
-        - log out
-        - switch from GNOME to *GNOME on Xorg*
-        - log back in
-        - finally, run `sudo apt install libx11-dev`
+- if you plan to use the install script, you also need `sudo apt install curl`. Curl handles the BTD6bot github repo content 
+downloading.
+
+- Linux has two different display protocols: **X (most recent version X11)** and **Wayland**. Modern distros use Wayland by default which is 
+build to be safer+modernized but also stricter than X11, and this causes some issues with ocr screenshot functions:
+    - on **X11**, Python library `mss` is used. It's the same one that bot's Windows version uses so no problems here. 
+    You probably need to 
+        - `sudo apt install libx11-dev` for X11 dependencies, and
+        - `sudo apt install gnome-screenshot` as a fallback (not 100% sure if required)
+        
+        but after these, everything should work just fine.
+    - on **Wayland**, `mss` doesn't work because its Linux version uses Xlib with XGetImage under the hood which then 
+    requires X11 again. There are currently no Python libraries that supports Wayland. On top of this, Wayland has different display implementations which will function differently.
+    
+        <u>Currently following compositor backends are supported:</u>
+        - x11 (works with mss)
+        - wlroots (requires *grim*, see **2.** below)
+
+        => So your only options are:
+
+        1. **Switch from Wayland display to X11 (if possible):**  
+        For example Debian + GNOME desktop uses GNOME Wayland which is not supported. However you can do the following:
+            - log out
+            - switch from GNOME to *GNOME on Xorg*
+            - log back in
+            - then `sudo apt install libx11-dev` + `sudo apt install gnome-screenshot` as mentioned earlier
+
+        2. **If wlroots-based display server, use *grim*:**  
+        Install [grim](https://gitlab.freedesktop.org/emersion/grim) if it's not already installed. With this, bot 
+        can use Python subprocess to call *grim* inside the code and take screenshots. Performance-wise very good and 
+        bot should operate as usual.
     
 - Before running any script, you **must** use `sudo chmod +x SCRIPT_NAME.sh` to treat shell file as an executable. 
 For example, first typing `sudo chmod +x run.sh` then `./run.sh` runs the bash script for btd6bot gui program.
@@ -73,7 +96,8 @@ For example, first typing `sudo chmod +x run.sh` then `./run.sh` runs the bash s
 example install xclip with `sudo apt xclip`
 
     While this step is somewhat optional, but you might be required to readjust game's resolution + window position. 
-    This is where `show_coordinates.sh` script in "./tools/show_coordinates" becomes useful and helps you to determine game window's top-left 
+    This is where `show_coordinates.sh` script in "./tools/show_coordinates" becomes useful and helps you to determine 
+    game window's top-left 
     coordinate.
 
 
@@ -124,7 +148,8 @@ Instructions:
    - download ZIP file of repo
    - download source code zip under newest release version
  
-2. read the operating-system help section. For Windows you probably don't need to do anything unless you install venv (step 3). For Linux there are multiple things you should check out.
+2. read the operating-system help section. For Windows you probably don't need to do anything unless you install venv 
+(step 3). For Linux there are multiple things you should check out.
 
 3. (optional) create and activate a virtual environment for local install; this way all required python packages 
 reside under 

--- a/btd6bot/Files/helpwindow/README.md
+++ b/btd6bot/Files/helpwindow/README.md
@@ -1,6 +1,6 @@
 # BTD6bot
 
-| ![](images/overview.png) |
+| ![](docs/images/overview.png) |
 |:--:|
 | *Overview of different gui windows (help window excluded)*|
 
@@ -75,15 +75,22 @@ Because of limited access to other operating systems than Windows, it's very dif
 all of them. Currently:
 - **Windows (10 or higher) is fully supported and thus recommended.**
 
-- **Linux**: tested partially on
-    - **Linux Mint 22.3 (Xfce)**
-    - **Debian 13.4 (GNOME)**
-    
-    Not all features have been tested, but since main functionalities (gui, kb+mouse automation, ocr) do work, bot 
-    should operate just fine.
+- **Linux**: 
 
-    Linux requires some additional dependencies to make Python, ocr, kb+mouse etc. function properly. These are 
-    documented and explained during installation process
+    Tested on following distros:
+    - **Linux Mint 22.3 (Xfce)**
+    - **Debian 13.4 (GNOME on Xorg)**
+    - **Linux Arch (Wayland with Hyprland)**
+    
+    At least gui, kb+mouse automation, and ocr functions have been tested on these distros which means bot should operate just fine.
+
+    => In general, **bot supports X11 or wlroots-based displays.** If your system has one of these available, you should be able to run the bot even if it's not listed above. How these relate to tested distros:
+    - Linux Mint uses X11
+    - Debian GNOME uses *GNOME Wayland* by default, which is based on KDE. This on itself will not work, but you can easily switch to *GNOME on Xorg* which uses X11
+    - Hyprland uses it's custom *aquamarine* compositor for Wayland which also retains wlroots compatibility.
+    
+    For more info, see [this section](_install/INSTALL.md#linux) of the install guide. It will used as a reference later and explains the X11/Wayland compatibility in more detail.
+
 - **MacOS => Not supported, but could still work** 
 
     Bot functionality remains largely untested without access to modern native Mac system i.e. owning a Mac PC. 
@@ -281,7 +288,7 @@ When you run the install script, it will download the current github main branch
 [**Notes**] 
 - You can move and rename `BTD6bot-main` directory freely, just don't rename any files inside it 
 unless you know what you're doing.
-- for more details such as step-by-step explanation of script code, check [here](_install/INSTALL.md)
+- for more details about what the scripts actually do, check [this](_install/INSTALL#detailed-explanation-of-scripts)
 
 ## Option 2: Manual install
 
@@ -301,7 +308,7 @@ For manual install, you have two options
 [**Method 2**]
 Click the green [<> Code] button at the top of github page.
 
-![](images/github_codebutton.png)
+![](docs/images/github_codebutton.png)
 
 Then either
 
@@ -351,7 +358,7 @@ and *tkinterweb-tkhtml* however they are mandatory:
 
 
 # <u>First-time setup</u>
-| ![](images/main/main.png) |
+| ![](docs/images/main/main.png) |
 |:--:|
 | *Main window default view*|
 
@@ -394,13 +401,13 @@ done, close hotkeys window.
     - If you use fullscreen, **don't** enable custom resolution, or use windowed mode. Just 
     leave it untoggled.
 
-        ![](images/settings/disable_custom.png)
+        ![](docs/images/settings/disable_custom.png)
 
     - If you use custom resolution, set width & height values, then update values.
         - Toggle windowed mode on if you wish to use it. **It's recommended to always use fullscreen**, but windowed 
         should also work - just requires a bit more setup.
 
-        ![](images/settings/custom_windowed.png)
+        ![](docs/images/settings/custom_windowed.png)
 
         For windowed mode you should head to [GUI settings](#settings) page as it's a little more complicated to explain
         here.
@@ -422,7 +429,7 @@ Easiest way to do setup all of this is to just press `Reset args` then `Set args
 
     Your argument prompt should look similar to this:
 
-    ![](images/settings/auto_adjust.png)
+    ![](docs/images/settings/auto_adjust.png)
 
     ***Why adjusting is needed**: monkey upgrading process is based on reading upgrade path names from screen and 
     matching these to static values. Different resolutions change the reading accuracy so bot will automatically adjust
@@ -463,7 +470,7 @@ Click the gear symbol and open hotkeys menu.
 
 Now update your game hotkeys for bot. Press "Set hotkeys" button in gui. Following window opens:
 
-| ![](images/hotkeys/hotkeys.png) |
+| ![](docs/images/hotkeys/hotkeys.png) |
 |:--:|
 | *Hotkey window*|
 
@@ -502,7 +509,7 @@ After you've updated all the keys, close the hotkey window.
 
 Next, open settings window by pressing "Settings" button.
 
-| ![](images/settings/settings.png) |
+| ![](docs/images/settings/settings.png) |
 |:--:|
 | *Settings window*|
 
@@ -532,7 +539,7 @@ option off, you should see your current resolution next to "Current resolution" 
 
     For example, if your monitor is `1920x1080`, you see following 
 
-    ![](images/settings/disable_custom.png)
+    ![](docs/images/settings/disable_custom.png)
 
 - *custom resolution*: type width and height in their respective entry boxes, then click the "Update resolution"
 button.  
@@ -541,11 +548,11 @@ Custom value is stored in a file and will be loaded back if you disable and re-e
     Example: if you have `1920x1080` as native res and set a custom res `1600x900`, then toggling setting on and off
     would display following resolutions:
 
-    ![](images/settings/difference.png)
+    ![](docs/images/settings/difference.png)
 
     With custom resolutions, you can enable *windowed mode*.
     
-    ![](images/settings/windowed.png)
+    ![](docs/images/settings/windowed.png)
     
     Setting up windowed mode requires a bit more explanation so go check [GUI settings](#settings) section.
 
@@ -556,7 +563,7 @@ Custom value is stored in a file and will be loaded back if you disable and re-e
 Lastly, enable the "Auto-adjust ocr upgrade data the next time a plan is run" option. 
 For 1920x1080 with fullscreen enabled, it looks like this:
 
-![](images/settings/auto_adjust.png)
+![](docs/images/settings/auto_adjust.png)
 
 
 It should include following parts, each separated by space:
@@ -580,11 +587,11 @@ Then just press "Set args" and you're done! You may now close the settings windo
 For last part, you need to enter the monitoring window. Click the "Initialize bot" button, located at bottom
 right of main window:
 
-![](images/main/init_button.png)
+![](docs/images/main/init_button.png)
 
 Following load message appears (or might just quickly flash if your computer is fast enough)
 
-![](images/main/load_msg.png)
+![](docs/images/main/load_msg.png)
 
 Program needs to load the ocr model into your temporary memory (RAM) each time you initialize bot and is therefore only
 required once per runtime loop. If you close the entire program and reopen it, the model must be loaded again.  
@@ -594,11 +601,11 @@ downloaded automatically by easyocr. This process is only for first-time setups 
 After the message disappears, model has been loaded and initialize button should now display "Open bot window"
 instead.
 
-![](images/main/openbotwin_button.png)
+![](docs/images/main/openbotwin_button.png)
 
 Click the button to open monitoring window.
 
-| ![](images/monitoring/monitoring.png) |
+| ![](docs/images/monitoring/monitoring.png) |
 |:--:|
 | *Monitoring window*|
 
@@ -684,7 +691,7 @@ This issue can be completely ignored now.
 -- End of explanation --
 ---
 
-| ![](images/monitoring/monitoring_adjustbegin.png) |
+| ![](docs/images/monitoring/monitoring_adjustbegin.png) |
 |:--:|
 | *After "Run" button is pressed and menu play button is detected, bot sets a countdown from 5 to 0, then begins the auto-adjusting process*|
 
@@ -723,7 +730,7 @@ following:
     future, just open setting and enable it again with appropriate arguments.
 
 
-| ![](images/monitoring/monitoring_adjustend.png) |
+| ![](docs/images/monitoring/monitoring_adjustend.png) |
 |:--:|
 | *Adjusting process complete. Current monitoring window must be closed in order to continue.*|
 
@@ -733,11 +740,11 @@ your bot is ready to be tested with an actual plan.
 To run your first plan, it's recommended to pick something simple. Close the monitoring window and select either
 `monkey meadow, easy-standard` or `dark castle, easy-standard` in main window:
 
-![](images/main/monkeymeadow.png)
+![](docs/images/main/monkeymeadow.png)
 
 or
 
-![](images/main/darkcastle.png)
+![](docs/images/main/darkcastle.png)
 
 Make sure you have the required hero, all monkeys and their upgrade paths unlocked. For upgrade paths:
 
@@ -767,7 +774,7 @@ to leave in-game resolution to your **native fullscreen resolution**, but still 
 
 When you run `Btd6bot` with windowed mode, it uses the logic described in following image
 
-![](images/settings/ultrawide.png)
+![](docs/images/settings/ultrawide.png)
 
 Because windowed mode normally leaves empty space around, you could limit the readable area to the middle of screen.
 A good example would be `3440x1440` resolution: it adds extra borders during maps which is 440 pixels each side. This
@@ -780,11 +787,11 @@ _Example:_ So if you have a `3440x1440` monitor and wish to play on this resolut
 
 - enable custom resolution and set it as `2560x1440`
 
-    ![](images/settings/3440x1440_settings.png)
+    ![](docs/images/settings/3440x1440_settings.png)
 
 - enable windowed mode and keep top-left value as "centered"
 
-    ![](images/settings/windowed.png)
+    ![](docs/images/settings/windowed.png)
 
     If value is not centered, simply type "centered" in one of the width/height fields and update
 
@@ -793,7 +800,7 @@ _Example:_ So if you have a `3440x1440` monitor and wish to play on this resolut
 
 Here's a visual explanation on the situation (in main menu screen, but this applies to in-game ui as well):
 
-![](images/settings/3440x1440example.png)
+![](docs/images/settings/3440x1440example.png)
 
 
 In general, check the following:
@@ -869,7 +876,7 @@ layout should remain the same.
 
 ## Main
 
-| ![](images/main/main_modified.png) |
+| ![](docs/images/main/main_modified.png) |
 |:--:|
 | *Main window, with ocr already initialized. Currently selected plan is bloody_puddlesHardChimps, with collection event and replay modes enabled.*|
 
@@ -919,7 +926,7 @@ Data is updated after each successful completion and also includes date of compl
 
 ## Help
 
-| ![](images/help/help.png) |
+| ![](docs/images/help/help.png) |
 |:--:|
 | *Help window, expanded to fullscreen. It displays the same README contents, however none of the links are in working condition*|
 
@@ -944,7 +951,7 @@ or reopening the Main window, this file gets deleted again!
 
 ## Queue
 
-| ![](images/queue/queue.png) |
+| ![](docs/images/queue/queue.png) |
 |:--:|
 | *Queue window with infernal_EasyStandard and flooded_valleyHardChimps plans placed in queue. When a plan is selected, its info text gets displayed.*|
 
@@ -1004,7 +1011,7 @@ window.
 
 ## Hotkeys
 
-| ![](images/hotkeys/hotkeys.png) |
+| ![](docs/images/hotkeys/hotkeys.png) |
 |:--:|
 | *Hotkey window.*|
 
@@ -1028,7 +1035,7 @@ any of them.
 
 ## Settings
 
-| ![](images/settings/settings.png) |
+| ![](docs/images/settings/settings.png) |
 |:--:|
 | *Settings window*|
 
@@ -1050,7 +1057,7 @@ option, which was already introduced when setting up the bot first time.
     
         To use windowed mode properly, you have to pinpoint the actual game window top-left coordinate:
 
-        ![](images/settings/windowed_topbar.png)
+        ![](docs/images/settings/windowed_topbar.png)
 
         See the **<u>Set window top left coordinate</u>** part below for more info.
     
@@ -1061,7 +1068,7 @@ option, which was already introduced when setting up the bot first time.
         To setup -popupwindow: if you use Steam version: library -> bloons td 6 -> right-click -> properties, then set 
         the following value
 
-        ![](images/settings/launchoption.png)
+        ![](docs/images/settings/launchoption.png)
 
         You can also add optional `-screen-width X` and `-screen-height Y` args here to force custom resolution, e.g. 
         `-popupwindow -screen-width 1920 -screen-height 1080`.
@@ -1212,7 +1219,7 @@ keep on trying, these texts must be as precisely readable as possible. For upgra
 
 ## Monitoring
 
-| ![](images/monitoring/monitoring.png) |
+| ![](docs/images/monitoring/monitoring.png) |
 |:--:|
 | *Monitoring window, with queue mode enabled. Current plan is quadHardChimps, with dark_castleHardChimps coming after.*|
 

--- a/btd6bot/bot/ocr/ocr.py
+++ b/btd6bot/bot/ocr/ocr.py
@@ -29,6 +29,9 @@ from PIL import Image
 import pyautogui
 from numpy import array, repeat
 
+from bot import _maindata, kb_mouse
+from customprint import cprint
+
 # desktop mode, mainly for selecting screenshot function for Linux X11 and Wayland, but includes also Win and Mac values
 # Linux: bot only supports
 # - x11 -> uses mss
@@ -46,7 +49,9 @@ elif sys.platform == "darwin":
 
     os_env = "mac"
 elif sys.platform == "linux":
-    session = os.environ.get("XDG_SESSION_TYPE").lower()
+    session = os.environ.get("XDG_SESSION_TYPE")
+    if session is not None:
+        session = session.lower()
 
     if session == "wayland":
         # don't use mss on Wayland. Instead use grim (https://gitlab.freedesktop.org/emersion/grim) subprocess calls
@@ -63,10 +68,6 @@ elif sys.platform == "linux":
         os_env = "x11"
     else:
         os_env = "unknown"
-
-
-from bot import _maindata, kb_mouse
-from customprint import cprint
 
 if TYPE_CHECKING:
     from easyocr import Reader
@@ -227,7 +228,6 @@ def weak_image_ocr(coordinates: tuple[int, int, int, int], reader: Reader) -> st
     tl_x, tl_y, br_x, br_y = coordinates[0], coordinates[1], coordinates[2], coordinates[3]
     width, height = br_x - tl_x, br_y - tl_y
     img: Any
-    ocr_img: Any
     final: Any
     if os_env in OcrValues._MSS_SUPPORTED and OcrValues._sct is not None:
         monitor = {"left": tl_x, "top": tl_y, "width": width, "height": height}
@@ -329,8 +329,8 @@ def weak_substring_check(input_str: str, coords: tuple[float, float, float, floa
     Returns:
         A boolean value depending on if the substring matched ocr string or not.
     """
-    (tl_x, tl_y) = kb_mouse.pixel_position((coords[0], coords[1]))
-    (br_x, br_y) = kb_mouse.pixel_position((coords[2], coords[3]))
+    tl_x, tl_y = kb_mouse.pixel_position((coords[0], coords[1]))
+    br_x, br_y = kb_mouse.pixel_position((coords[2], coords[3]))
     text = weak_image_ocr((tl_x, tl_y, br_x, br_y), reader)
     if _maindata.maindata["bot_vars"]["substring_ocrtext"]:
         cprint("\nText: " + text.lower() + "\nInput: " + input_str.lower())
@@ -387,8 +387,8 @@ def strong_delta_check(
     Returns:
         A boolean value depending on if upgrade strings are similar enough (above DELTA threshold) or not.
     """
-    (tl_x, tl_y) = kb_mouse.pixel_position((coords[0], coords[1]))
-    (br_x, br_y) = kb_mouse.pixel_position((coords[2], coords[3]))
+    tl_x, tl_y = kb_mouse.pixel_position((coords[0], coords[1]))
+    br_x, br_y = kb_mouse.pixel_position((coords[2], coords[3]))
     text = strong_image_ocr((tl_x, tl_y, br_x, br_y), reader)
     if len(text) != 0:
         if input_str == "_upgrade_":
@@ -449,8 +449,8 @@ def strong_substring_check(
         A tuple of boolean value and found ocr string in lowercase. Boolean is True if text is found as substring in
             input, otherwise False.
     """
-    (tl_x, tl_y) = kb_mouse.pixel_position((coords[0], coords[1]))
-    (br_x, br_y) = kb_mouse.pixel_position((coords[2], coords[3]))
+    tl_x, tl_y = kb_mouse.pixel_position((coords[0], coords[1]))
+    br_x, br_y = kb_mouse.pixel_position((coords[2], coords[3]))
     text = strong_image_ocr((tl_x, tl_y, br_x, br_y), reader)
     text_lower = text.lower()
     if _maindata.maindata["bot_vars"]["substring_ocrtext"]:

--- a/btd6bot/bot/ocr/ocr.py
+++ b/btd6bot/bot/ocr/ocr.py
@@ -6,16 +6,20 @@ this was much slower, like 25-30% slower with monkey upgrades than screen_ocr, b
 
 Now, current one is easyocr: it seems even more accurate, or at least ocr temp get very good matches from one another
 so upgrading monkeys works consistently so far; obviously there could be problematic cases but only time will tell.
-Also similar speed-wise to tesseract; would be a lot slower with all the processing, but now for example zooming of 
+Also similar speed-wise to tesseract; would be a lot slower with all the processing, but now for example zooming of
 images is no longer necessary which saves time. Easyocr does have the initial reader setup delay, which is done before
 launching program: it takes like 10 seconds, but isn't required afterwards as reader is loaded from ocr_reader and
-passed as a variable to all implemented reader-utilizing tools. Also a major plus with easyocr is that it can be 
+passed as a variable to all implemented reader-utilizing tools. Also a major plus with easyocr is that it can be
 installed entirely as a Python package whereas tesseract requires an executable file on top of its code library.
 
 After reader is initialized, it will reserve quite a sizeable chunk in memory: at least about 400MB.
 """
 
 from __future__ import annotations
+import io
+import os
+import shutil
+import subprocess
 from typing import TYPE_CHECKING
 import difflib
 import sys
@@ -24,53 +28,117 @@ import time
 from PIL import Image
 import pyautogui
 from numpy import array, repeat
-# https://python-mss.readthedocs.io/usage.html#import
-if sys.platform == 'win32': 
+
+# desktop mode, mainly for selecting screenshot function for Linux X11 and Wayland, but includes also Win and Mac values
+# Linux: bot only supports
+# - x11 -> uses mss
+# - wlroots -> uses grim via subprocess calls
+# Other wayland displays = not yet as there's no easy way to add support for them
+os_env: str = "unknown"
+
+if sys.platform == "win32":
+    # https://python-mss.readthedocs.io/usage.html#import
     from mss.windows import MSS as mss
-elif sys.platform == 'darwin':
+
+    os_env = "windows"
+elif sys.platform == "darwin":
     from mss.darwin import MSS as mss
-elif sys.platform == 'linux':
-    from mss.linux import MSS as mss
+
+    os_env = "mac"
+elif sys.platform == "linux":
+    session = os.environ.get("XDG_SESSION_TYPE").lower()
+
+    if session == "wayland":
+        # don't use mss on Wayland. Instead use grim (https://gitlab.freedesktop.org/emersion/grim) subprocess calls
+        # IMPORTANT: grim works only on wlroots displays like Hyprland. For instance, GNOME Wayland has it's custom
+        # gnome-screenshot, but this uses interactive area selection and cannot be passed area flags from CLI
+        if shutil.which("grim"):  # verify grim installation
+            os_env = "wayland_wlroots"
+        else:
+            cprint("Error: grim installation not found")
+            os_env = "unknown"
+    elif session == "x11":
+        from mss.linux import MSS as mss
+
+        os_env = "x11"
+    else:
+        os_env = "unknown"
+
 
 from bot import _maindata, kb_mouse
 from customprint import cprint
 
 if TYPE_CHECKING:
     from easyocr import Reader
-    from typing import Any
+    from typing import Any, cast
+
 
 class OcrValues:
     """Wrapper class: constants required for optical character recognition tools.
 
     Attributes:
         DELTA (float, constant class attribute):
-            Controls OCR string matching accuracy in strong_delta_check for general strings - upgrade string are 
-            handled separately. Delta value itself is included i.e. 0.8 means that all deltas on closed interval 
-            [0.8, 1] are valid.
-        
-        read_file_frequency (float, class attribute):
-            Text recognition check rate in both find_text and check_upg_text: lower number increases rate of checking, 
-            but also increases CPU usage significantly. Frequency itself is just a pause timer in seconds so 1 equals 
-            to ~1 check a second, but this doesn't include the other part of process like screenshots, reading text 
-            and comparing text. This means the actual frequency to checks ratio diminishes greatly with smaller value 
-            i.e. 0.01 doesn't match to 100 checks per second.
+            Controls OCR string matching accuracy in strong_delta_check for general strings - upgrade string are
+            handled separately. Delta value itself is included i.e. 0.8 means that all deltas on closed interval
+            [0.8, 1] are valid. Current value is 0.75.
     """
+
     DELTA: float = 0.75
 
-    _baseres: tuple[int, ...] = tuple(map(int, str(_maindata.maindata["bot_vars"]["custom_resolution"]).split('x')))
+    _MSS_SUPPORTED = {"windows", "mac", "x11"}
+
+    _sct = None
+    if os_env in _MSS_SUPPORTED:
+        _sct = mss()
+    _baseres: tuple[int, ...] = tuple(map(int, str(_maindata.maindata["bot_vars"]["custom_resolution"]).split("x")))
     _read_file_frequency: float = _maindata.maindata["bot_vars"]["ocr_frequency"]
-    _log_ocr_deltas: bool = False # only _adjust_deltas.py should set this to True  
+    _log_ocr_deltas: bool = False  # only _adjust_deltas.py should set this to True
     _ocr_upgradedata: dict[str, Any] = _maindata.maindata["ocr_upgradedata"]
     _ocr_upg_basedata: dict[str, Any] = _maindata.maindata["ocr_basedata"]
 
+
+def _wayland_grab(coordinates: tuple[int, int, int, int]) -> Image.Image:
+    raw_img: Any
+    tl_x, tl_y, br_x, br_y = coordinates
+    width, height = br_x - tl_x, br_y - tl_y
+    if width <= 0 or height <= 0:
+        raise ValueError("Invalid screenshot dimensions")
+    time.sleep(0.05)
+    try:
+        region = f"{tl_x},{tl_y}, {width}x{height}"
+        cmd = ["grim", "-g", region, "-t", "ppm", "-"]  # write into stdout -> saving images should not be required
+        raw_img = subprocess.check_output(cmd, timeout=5)
+    except subprocess.CalledProcessError as e:
+        cprint("grim failed: ", e.stderr)
+    return Image.open(io.BytesIO(raw_img)).convert("RGB")
+
+
+def _wayland_pixelcolor(x: float, y: float) -> tuple[int, int, int]:
+    raw_img: Any
+    px, py = kb_mouse.pixel_position((x, y))
+    time.sleep(0.05)
+    try:
+        region = f"{px},{py}, 1x1"
+        cmd = ["grim", "-g", region, "-t", "ppm", "-"]
+        raw_img = subprocess.check_output(cmd, timeout=5)
+    except subprocess.CalledProcessError as e:
+        cprint("grim failed: ", e.stderr)
+    img = Image.open(io.BytesIO(raw_img)).convert("RGB")
+    pixel: tuple[int, int, int] = cast(tuple[int, int, int], img.getpixel((0, 0)))  # type cast for mypy
+    return pixel
+
+
 def get_pixelcolor(x: float, y: float) -> tuple[int, int, int]:
     """Returns rgb color tuple of a coordinate location.
-    
+
     Coordinates are passed as scalar values [0,1).
     """
+    if sys.platform == "linux" and os_env == "wayland_wlroots":
+        return _wayland_pixelcolor(x, y)
     px, py = kb_mouse.pixel_position((x, y))
-    color: tuple[int, int, int] = pyautogui.pixel(px,py) # explicit typing for mypy
+    color: tuple[int, int, int] = pyautogui.pixel(px, py)  # explicit typing for mypy
     return color
+
 
 def white_shades(rgb_range: int = 1) -> list[tuple[int, int, int]]:
     """Returns a list of different shades of white color. By default, only white (255,255,255) is returned.
@@ -80,7 +148,7 @@ def white_shades(rgb_range: int = 1) -> list[tuple[int, int, int]]:
     tools. Is used with strong_image_ocr method.
 
     Args:
-        rgb_range: Integer value that determines the range of shades. Default value is 1. 
+        rgb_range: Integer value that determines the range of shades. Default value is 1.
 
     Returns:
         white_list: List of color tuples.
@@ -89,9 +157,10 @@ def white_shades(rgb_range: int = 1) -> list[tuple[int, int, int]]:
     for i in range(0, rgb_range):
         for j in range(0, rgb_range):
             for k in range(0, rgb_range):
-                w = (255-i, 255-j, 255-k)
+                w = (255 - i, 255 - j, 255 - k)
                 white_list.extend([w])
     return white_list
+
 
 def gray_shades(rgb_range: int = 1) -> list[tuple[int, int, int]]:
     """Returns a list of different shades of gray color. By default, only gray value (160,164,174) is returned.
@@ -108,37 +177,39 @@ def gray_shades(rgb_range: int = 1) -> list[tuple[int, int, int]]:
     for i in range(0, rgb_range):
         for j in range(0, rgb_range):
             for k in range(0, rgb_range):
-                g1 = (160-i, 164-j, 174-k)
-                g2 = (160+i, 164+j, 174+k)
+                g1 = (160 - i, 164 - j, 174 - k)
+                g2 = (160 + i, 164 + j, 174 + k)
                 gray_list.extend([g1, g2])
     return gray_list
 
+
 def img_to_black_and_white(image: Image.Image) -> Image.Image:
     """Return an image with non-white and non-grey shades replaced with black.
-      
-    This leaves white text with black background and makes ocr matching possibly more accurate. 
+
+    This leaves white text with black background and makes ocr matching possibly more accurate.
     Used in strong_image_ocr.
 
     Args:
         image: A PIL.ImageFile.ImageFile object
 
     Returns:
-        img: Original image, but with only white/gray and black colors. Type is the same, ImageFile.
+        img: Original image, but with only white/gray and black colors.
     """
     img = image
-    width, height = img.size[0], img.size[1] 
-    for i in range(0, width): # process all pixels
+    width, height = img.size[0], img.size[1]
+    for i in range(0, width):  # process all pixels
         for j in range(0, height):
-            data = img.getpixel((i,j))
+            data = img.getpixel((i, j))
             if data in gray_shades() or data in white_shades():
-                img.putpixel((i,j), (255, 255, 255))              
+                img.putpixel((i, j), (255, 255, 255))
             else:
-                img.putpixel((i,j),(0, 0, 0))
+                img.putpixel((i, j), (0, 0, 0))
     return img
+
 
 def weak_image_ocr(coordinates: tuple[int, int, int, int], reader: Reader) -> str:
     """Extracts text from an image and returns this text as a string.
-    
+
     Takes a monitor screenshot on passed coordinate location, then open this image in a format the easyocr reader
     can utilize, reads text, and finally return the extracted text string.
 
@@ -155,22 +226,31 @@ def weak_image_ocr(coordinates: tuple[int, int, int, int], reader: Reader) -> st
     """
     tl_x, tl_y, br_x, br_y = coordinates[0], coordinates[1], coordinates[2], coordinates[3]
     width, height = br_x - tl_x, br_y - tl_y
-    with mss() as sct:
+    img: Any
+    ocr_img: Any
+    final: Any
+    if os_env in OcrValues._MSS_SUPPORTED and OcrValues._sct is not None:
         monitor = {"left": tl_x, "top": tl_y, "width": width, "height": height}
-        ocr_img = sct.grab(monitor)
-    img = array(ocr_img)
+        img = OcrValues._sct.grab(monitor)
+    elif os_env == "wayland_wlroots":
+        img = _wayland_grab((tl_x, tl_y, br_x, br_y))
+    else:
+        raise RuntimeError("Unsupported display environment")
+
+    final = array(img)
     try:
-        result = reader.readtext(img)
-        string = ''
+        result = reader.readtext(final)
+        string = ""
         for r in result:
             string += r[1]
-    except ValueError:  
-        string = ''
+    except ValueError:
+        string = ""
     return string
+
 
 def strong_image_ocr(coordinates: tuple[int, int, int, int], reader: Reader) -> str:
     """Extracts text from an image by making them first black and white/gray-shaded, and then performing ocr on them.
-     
+
     Similar to weak_image_ocr, but images are processed with a function that sets other but white/gray pixels to black:
     white and gray are upgrade text labels. So end results is black background with text elements in white & gray
     colors: this clears most junk so that 2 OCR image strings are easy to match.
@@ -185,47 +265,61 @@ def strong_image_ocr(coordinates: tuple[int, int, int, int], reader: Reader) -> 
     """
     tl_x, tl_y, br_x, br_y = coordinates[0], coordinates[1], coordinates[2], coordinates[3]
     width, height = br_x - tl_x, br_y - tl_y
-    with mss() as sct:
+    img: Any
+    ocr_img: Any
+    final: Any
+    if os_env in OcrValues._MSS_SUPPORTED and OcrValues._sct is not None:
         monitor = {"left": tl_x, "top": tl_y, "width": width, "height": height}
-        img = sct.grab(monitor)
-    ocr_img = Image.frombytes("RGB", img.size, img.bgra, "raw", "BGRX")
-    blackwhite_image = img_to_black_and_white(ocr_img)
+        ocr_img = OcrValues._sct.grab(monitor)
+        img = Image.frombytes("RGB", ocr_img.size, ocr_img.bgra, "raw", "BGRX")  # this is probably not even needed
+    elif os_env == "wayland_wlroots":
+        img = _wayland_grab((tl_x, tl_y, br_x, br_y))
+    else:
+        raise RuntimeError("Unsupported display environment")
+
+    blackwhite_image = img_to_black_and_white(img)
     final = array(blackwhite_image)
-    if (_maindata.maindata["bot_vars"]["windowed"] and
-        (kb_mouse.ScreenRes._width < kb_mouse.ScreenRes.BASE_RES[0] or
-        kb_mouse.ScreenRes._height < kb_mouse.ScreenRes.BASE_RES[1])):
-        zoom_factor: int # add some zoom based on game window size
-        if (kb_mouse.ScreenRes.BASE_RES[0] < 2*kb_mouse.ScreenRes._width or
-            kb_mouse.ScreenRes.BASE_RES[1] < 2*kb_mouse.ScreenRes._height): # if window w/h more than half of native res
+
+    if _maindata.maindata["bot_vars"]["windowed"] and (
+        kb_mouse.ScreenRes._width < kb_mouse.ScreenRes.BASE_RES[0]
+        or kb_mouse.ScreenRes._height < kb_mouse.ScreenRes.BASE_RES[1]
+    ):
+        zoom_factor: int  # add some zoom based on game window size
+        if (
+            kb_mouse.ScreenRes.BASE_RES[0] < 2 * kb_mouse.ScreenRes._width
+            or kb_mouse.ScreenRes.BASE_RES[1] < 2 * kb_mouse.ScreenRes._height
+        ):  # if window w/h more than half of native res
             zoom_factor = 2
         else:
             zoom_factor = 3
-        for i in range(2): # zooming of images, quite expensive to calculate.
+        for i in range(2):  # zooming of images, quite expensive to calculate.
             final = repeat(final, zoom_factor, axis=i)
+
     try:
         result = reader.readtext(final)
-        string = ''
+        string = ""
         for r in result:
             string += r[1]
     except ValueError:
-        string = ''
+        string = ""
     return string
-    
+
+
 def weak_substring_check(input_str: str, coords: tuple[float, float, float, float], reader: Reader) -> bool:
     """Attempts to find inputted string from screenshot ocr string by substring matching.
 
     Tries to read the input_str from screen within specified coordinates. If it's found, returns True, otherwise False.
     Order of coordinates: (left, top, right, bottom), meaning (top_left x, top_left y, bottom_right x, bottom_right y),
     naturally topleft_x < bottomright_x and topleft_y < bottomright_y, otherwise throws error. Uses weak_image_ocr
-    function as text extractor: this does far less modifying of current image, but matches much better with certain 
-    static/pre-typed strings than strong_image_ocr. 
-    
-    Use cases:  
-    -checking menu play button text,  
-    -when game begins i.e. locating 'upgrade' text. Will not check game ending, however, as this still has weird 
-        inconsistencies.  
-    -finding the defeat screen 'bloons leaked' message.  
-    
+    function as text extractor: this does far less modifying of current image, but matches much better with certain
+    static/pre-typed strings than strong_image_ocr.
+
+    Use cases:
+    -checking menu play button text,
+    -when game begins i.e. locating 'upgrade' text. Will not check game ending, however, as this still has weird
+        inconsistencies.
+    -finding the defeat screen 'bloons leaked' message.
+
     Args:
         input_str: The substring that should be contained within ocr string.
         coords: Image location, an integer-valued 4-tuple. First two values correspond to top-left (x,y)
@@ -239,44 +333,46 @@ def weak_substring_check(input_str: str, coords: tuple[float, float, float, floa
     (br_x, br_y) = kb_mouse.pixel_position((coords[2], coords[3]))
     text = weak_image_ocr((tl_x, tl_y, br_x, br_y), reader)
     if _maindata.maindata["bot_vars"]["substring_ocrtext"]:
-        cprint("\nText: "+text.lower()+'\nInput: '+input_str.lower())
+        cprint("\nText: " + text.lower() + "\nInput: " + input_str.lower())
     if len(text) != 0 and text.lower().find(input_str.lower()) != -1:
         return True
     time.sleep(OcrValues._read_file_frequency)
     return False
 
-def strong_delta_check(input_str: str, coords: tuple[float, float, float, float], reader: Reader, upg_match: str = ''
-                       ) -> bool:
+
+def strong_delta_check(
+    input_str: str, coords: tuple[float, float, float, float], reader: Reader, upg_match: str = ""
+) -> bool:
     """Attempts to match a string with strong_image_ocr string by their similarity.
 
     Differs from substring checking by using a delta parameter which compares similar symbols in two strings.
-    This makes it powerful when matching to complex ocr like upgrade texts, or two ocr strings (latter was used before 
-    but has currently no use). However, for simpler static string matching, it faces the problem of over-processing 
-    inputs and thus makes bad errors, like passing rounds and creating mismatch between current round that bot sees and 
-    actual game round. Thus, this responsibility is left for weak_substring_check instead.  
+    This makes it powerful when matching to complex ocr like upgrade texts, or two ocr strings (latter was used before
+    but has currently no use). However, for simpler static string matching, it faces the problem of over-processing
+    inputs and thus makes bad errors, like passing rounds and creating mismatch between current round that bot sees and
+    actual game round. Thus, this responsibility is left for weak_substring_check instead.
     To add to above, delta matching is still very effective on some simple static strings. For example, when a monkey/
-    hero is placed, ocr checks this by reading the 'sell' text. But quite often this string is either missing one of 
-    the letters 'l' or one gets replaced by 'i' or 1, making substring matching ineffective. But with enough delta, ocr 
+    hero is placed, ocr checks this by reading the 'sell' text. But quite often this string is either missing one of
+    the letters 'l' or one gets replaced by 'i' or 1, making substring matching ineffective. But with enough delta, ocr
     can identify them as same.
-    
+
     'difflib' module offers ways to compare objects like strings and return a value which measures their similarity.
     SequenceMatcher matches two strings with optional junk symbol detector: this allows to ignore spaces/tabs and
     possibly other values that shouldn't be part of matching. The quick_ratio is used to return upper bound of
     difference between sequences and is much faster to calculate. Return values (= deltas) are on interval [0,1]
     where 0 is for entirely different strings and 1 for perfect matches.
 
-    Deltas shouldn't be too high either as ocr could reject valid strings. And in some cases, relatively high delta can 
-    still match two different upgrades. For this reason, all upgrade strings are saved in OcrValues.OCR_UPGRADE_DATA 
-    dictionary, where each string has individual delta: this helps with tweaking problematic cases individually. For 
+    Deltas shouldn't be too high either as ocr could reject valid strings. And in some cases, relatively high delta can
+    still match two different upgrades. For this reason, all upgrade strings are saved in OcrValues.OCR_UPGRADE_DATA
+    dictionary, where each string has individual delta: this helps with tweaking problematic cases individually. For
     non-upgrade strings, a general delta value OcrValues.DELTA works just fine, which should be at least 0.7.
 
     Like mentioned, uses quick_ratio() instead of ratio() due to it being considerably faster.
 
-    Use cases:  
-    -upgrading monkeys,  
-    -checking 'sell' text when placing monkeys; high enough DELTA will match even with one letter mismatch when it 
-        spells 'sel' instead,  
-    -end screen 'next' text (again, simple short text but can still cause error in a single letter so high DELTA 
+    Use cases:
+    -upgrading monkeys,
+    -checking 'sell' text when placing monkeys; high enough DELTA will match even with one letter mismatch when it
+        spells 'sel' instead,
+    -end screen 'next' text (again, simple short text but can still cause error in a single letter so high DELTA
         helps),
     -checking collection event 'Collect' text.
 
@@ -285,7 +381,7 @@ def strong_delta_check(input_str: str, coords: tuple[float, float, float, float]
         coords: Image location, an integer-valued 4-tuple. First two values correspond to top-left (x,y)
             location, last two to bottom-right (x,y) location.
         reader: An easyocr.Reader object that handles reading from image. Loaded from ocr_reader.py.
-        upg_match: Identification string if ocr is performed for upgrade strings. Upgrades are listed under 
+        upg_match: Identification string if ocr is performed for upgrade strings. Upgrades are listed under
             OcrValues.OCR_UPGRADE_DATA
 
     Returns:
@@ -295,7 +391,7 @@ def strong_delta_check(input_str: str, coords: tuple[float, float, float, float]
     (br_x, br_y) = kb_mouse.pixel_position((coords[2], coords[3]))
     text = strong_image_ocr((tl_x, tl_y, br_x, br_y), reader)
     if len(text) != 0:
-        if input_str == '_upgrade_':
+        if input_str == "_upgrade_":
             if OcrValues._log_ocr_deltas:
                 match = OcrValues._ocr_upg_basedata[upg_match]
                 match_str: str = match[0]
@@ -303,32 +399,36 @@ def strong_delta_check(input_str: str, coords: tuple[float, float, float, float]
                 match = OcrValues._ocr_upgradedata[upg_match]
                 match_str = match[0]
                 delta_limit: float = match[1]
+
             d = difflib.SequenceMatcher(lambda x: x in "\t", text.lower(), match_str).quick_ratio()
             if _maindata.maindata["bot_vars"]["delta_ocrtext"]:
-                cprint('\n-Text: '+text.lower())
-                cprint("-Match delta: "+str(d))
+                cprint("\n-Text: " + text.lower())
+                cprint("-Match delta: " + str(d))
                 if OcrValues._log_ocr_deltas:
                     if len(str(d)) <= 4:
                         add_dict = {upg_match: [match_str, d]}
                     else:
-                        add_dict = {upg_match: [match_str, round(d-0.005, 2)]}
+                        add_dict = {upg_match: [match_str, round(d - 0.005, 2)]}
                     _maindata.maindata["temp_upg_deltas"].update(add_dict)
                     return True
+
             if d >= delta_limit:
                 return True
-        elif input_str != '':
+        elif input_str != "":
             r = difflib.SequenceMatcher(lambda x: x in "\t", text.lower(), input_str.lower()).quick_ratio()
             if _maindata.maindata["bot_vars"]["delta_ocrtext"]:
-                cprint('\n-Input: '+input_str.lower()+'\n-Text: '+text.lower()+'\n-Delta: '+str(r))
+                cprint("\n-Input: " + input_str.lower() + "\n-Text: " + text.lower() + "\n-Delta: " + str(r))
             if r >= OcrValues.DELTA:
                 return True
     time.sleep(OcrValues._read_file_frequency)
     return False
 
-def strong_substring_check(input_str: str, coords: tuple[float, float, float, float], reader: Reader
-                           ) -> tuple[bool, str]:
+
+def strong_substring_check(
+    input_str: str, coords: tuple[float, float, float, float], reader: Reader
+) -> tuple[bool, str]:
     """Attempts to find inputted string from screenshot ocr string by substring matching with black and white text box.
-    
+
     Middle ground for weak_substring_check and strong_delta_check: uses strong_image_ocr to get black and white text
     box, but still uses substring matching instead of DELTA.
 
@@ -336,7 +436,7 @@ def strong_substring_check(input_str: str, coords: tuple[float, float, float, fl
     rounds is more complex, so black background makes it easier - this was particularly problematic if round message
     is shorter than, say, 'round .../100' text of impoppable/chimps.
 
-    Use cases:  
+    Use cases:
         -checking current round text.
 
     Args:
@@ -346,7 +446,7 @@ def strong_substring_check(input_str: str, coords: tuple[float, float, float, fl
         reader: An easyocr.Reader object that handles reading text from image. Loaded from ocr_reader.py.
 
     Returns:
-        A tuple of boolean value and found ocr string in lowercase. Boolean is True if text is found as substring in 
+        A tuple of boolean value and found ocr string in lowercase. Boolean is True if text is found as substring in
             input, otherwise False.
     """
     (tl_x, tl_y) = kb_mouse.pixel_position((coords[0], coords[1]))
@@ -354,7 +454,7 @@ def strong_substring_check(input_str: str, coords: tuple[float, float, float, fl
     text = strong_image_ocr((tl_x, tl_y, br_x, br_y), reader)
     text_lower = text.lower()
     if _maindata.maindata["bot_vars"]["substring_ocrtext"]:
-        cprint("\nText: "+text_lower+'\nInput: '+input_str.lower())
+        cprint("\nText: " + text_lower + "\nInput: " + input_str.lower())
     if len(text) != 0 and text_lower.find(input_str.lower()) != -1:
         return (True, text_lower)
     time.sleep(OcrValues._read_file_frequency)

--- a/btd6bot/bot/rounds.py
+++ b/btd6bot/bot/rounds.py
@@ -54,6 +54,7 @@ class Rounds:
     @staticmethod
     def _check_gamesettings() -> None:
         if Rounds.escsettings_check:
+            cprint(">Checking game settings...")
             kb_mouse.press_esc()
             time.sleep(0.5)
 
@@ -68,7 +69,7 @@ class Rounds:
                 time.sleep(0.5)
             if nugde[2] != 0:
                 kb_mouse.click(get_click("ingame", "nudge"))
-                cprint("Disabled nugde mode'")
+                cprint("Disabled 'nugde mode'")
                 time.sleep(0.5)
             if autostart[2] != 0:
                 kb_mouse.click(get_click("ingame", "autostart"))
@@ -77,11 +78,12 @@ class Rounds:
                 time.sleep(0.5)
             if hints[2] == 0:
                 kb_mouse.click(get_click("ingame", "hints"))
-                cprint("Disabled game hints")
+                cprint("Disabled 'game hints'")
                 time.sleep(0.5)
 
             kb_mouse.press_esc()
             Rounds.escsettings_check = False
+            cprint(">Check completed.\n")
 
     @staticmethod
     def _defeat_return(exit_str: str) -> None:

--- a/btd6bot/gui/main_window.py
+++ b/btd6bot/gui/main_window.py
@@ -155,9 +155,9 @@ class MainWindow:
         self.root.rowconfigure(0, weight=1)
         # Linux
         if sys.platform == "linux":
-            self.root.geometry("690x465+700+300")
-            self.root.minsize(690, 465)
-            self.root.maxsize(690, 465)
+            self.root.geometry("700x465+700+300")
+            self.root.minsize(700, 465)
+            self.root.maxsize(700, 465)
         else:
             self.root.geometry("655x442+700+300")
             self.root.minsize(655, 442)

--- a/btd6bot/gui/monitoring_window.py
+++ b/btd6bot/gui/monitoring_window.py
@@ -71,9 +71,9 @@ class MonitoringWindow:
         icon = tk.PhotoImage(file=gui_paths.FILES_PATH / "btd6bot.png")
         self.monitoringwindow.iconphoto(True, icon)
         if sys.platform == "linux":
-            self.monitoringwindow.geometry("805x505")
-            self.monitoringwindow.minsize(805, 505)
-            self.monitoringwindow.maxsize(805, 505)
+            self.monitoringwindow.geometry("815x505")
+            self.monitoringwindow.minsize(815, 505)
+            self.monitoringwindow.maxsize(815, 505)
         else:
             self.monitoringwindow.geometry("800x480")
             self.monitoringwindow.minsize(800, 480)


### PR DESCRIPTION
Bot should now work with Linux distros that use wlroots-based compositor in their Wayland display server. Because Python's mss can't be used directly, the screenshot process is handled using `grim`. As grim is CLI-based, it must be called via Python subprocess. This however seems to work pretty much the same as mss which is great.

For example, Hyprland supports wlroots and has been confirmed to work on Linux Arch thanks to @Schnurzel700. They have also provided code in their custom fork which has been adapted into main code with some changes. Notably no external screenshot saving should be required and instead grim redirects output into Python's standard output (stdout). 

This version of code has not been tested, but as it pretty much the same implemenation as explained above, it should be ok. Maybe stdout-based image processing could cause some unforseen side effects.

