### PR TITLE
[v1.0.2] Bug fixes + small, but important update to apopalypse mode processing

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -1,4 +1,4 @@
-# Supported game plans (Last updated 2026-04-30)
+# Supported game plans (Last updated 2026-05-01)
 
 - this list is auto-updated using ``scripts/update_plans.py``
 - all implemented plans are listed. Each game mode includes

--- a/Plans.md
+++ b/Plans.md
@@ -986,7 +986,8 @@
 			
 			village 0-2-0
 			_______________________________________
-			Apopalypse round rng might fail you. Should work after a few tries, though.
+			Apopalypse round rng might fail you, should work after a few tries, though. This happens on zero monkey knowledge, but
+			if you have some of the more important ones, this should work 100% of the time.
 			
 - Hard
 	- [Chimps](btd6bot/plans/infernalHardChimps.py)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ section.
 ---
 #### [Update status]
 
-- Latest version of bot is **1.0.0** which matches BTD6's *Update 54*. 
+- Latest version of bot is **1.0.2** which matches BTD6's *Update 54*. 
 
     => Release notes can be found [here](https://github.com/j-miet/BTD6bot/releases/tag/v1.0.0)
     - For now, bot is planned to be updated after each major game update. These **updates** are marked as `1.X.0`
@@ -45,7 +45,7 @@ section.
 
     => Plans were previously updated in **1.0.0**. Next update cycle is scheduled for **1.2.0**.
 
-    - <u>Main goal is to keep all Chimps plans updated and add any missing ones</u>. This process is repeated 
+    - <u>Main goal is to keep all Chimps plans available and updated</u>. This process is repeated 
     **every 2-3 updates**. Other plans could stay untested for extended periods of time, but then again, are also less 
     affected by tower balancing/price changes.
 
@@ -82,14 +82,19 @@ all of them. Currently:
     - **Debian 13.4 (GNOME on Xorg)**
     - **Linux Arch (Wayland with Hyprland)**
     
-    At least gui, kb+mouse automation, and ocr functions have been tested on these distros which means bot should operate just fine.
+    At least gui, kb+mouse automation, and ocr functions have been tested on these distros which means bot should 
+    operate just fine.
 
-    => In general, **bot supports X11 or wlroots-based displays.** If your system has one of these available, you should be able to run the bot even if it's not listed above. How these relate to tested distros:
+    => In general, **bot supports X11 or wlroots-based displays.** If your system has one of these available, you 
+    should be able to run the bot even if it's not listed above. How these relate to tested distros:
     - Linux Mint uses X11
-    - Debian GNOME uses *GNOME Wayland* by default, which is based on KDE. This on itself will not work, but you can easily switch to *GNOME on Xorg* which uses X11
-    - Hyprland uses it's custom *aquamarine* compositor for Wayland which also retains wlroots compatibility.
+    - Debian GNOME uses *GNOME Wayland* by default, which intentionally limits screenshots to be 
+    interactive/user-controlled, preventing code-level access. However you can easily switch to *GNOME on Xorg* which 
+    uses X11
+    - Hyprland uses it's custom *aquamarine* compositor for Wayland which also retains wlroots compatibility
     
-    For more info, see [this section](_install/INSTALL.md#linux) of the install guide. It will used as a reference later and explains the X11/Wayland compatibility in more detail.
+    For more info, see [this section](_install/INSTALL.md#linux) of the install guide. It will used as a reference 
+    later and explains the X11/Wayland compatibility in more detail.
 
 - **MacOS => Not supported, but could still work** 
 
@@ -99,14 +104,49 @@ all of them. Currently:
     - some code-level testing has been done using VirtualBox on much older versions (Catalina, Big Sur):
         - custom gui-only hotkeys are disabled for Mac systems. Reason is Python libraries used for gui and 
         hotkeys (`tkinter` & `pynput` respectively) interfere with each other due to them running on same main thread. 
-        Thus hotkeys must be typed manually. Also bot can be still halted without hotkeys by quickly dragging mouse cursor to upper-left corner.
+        Thus hotkeys must be typed manually. Also bot can be still halted without hotkeys by quickly dragging mouse 
+        cursor to upper-left corner.
         - mac uses `16:10` aspect ratio as a baseline and lacks the support for recommended `16:9` resolutions. Again, 
     this can probably be fixed by using the tricks explained above in resolution section.
-        - if using running the bot inside gui doesn't work, you can use the no-gui version of bot. You can still use gui to update settings, hotkeys and plan queue, then close gui and switch to no-gui version.
+        - if using running the bot inside gui doesn't work, you can use the no-gui version of bot. You can still use 
+        gui to update settings, hotkeys and plan queue, then close gui and switch to no-gui version.
 
 The only *"OS-independent solution"* would be a dual boot setup: install a separate Windows version/widely supported 
 Linux distribution, then run btd6 + bot in this environment.
 - Don't try to use virtual machine. These cannot properly utilize GPU which makes your game run on extremely low fps.
+
+#### [Keyboard languages]
+
+There's an issue with keyboard value conversion with different input languages on keyboard. This reason is current system stores values in strings instead of keycodes.
+
+Current saving process:
+- user gives input
+- input is parsed. This can happen in three ways:
+    - store a character literal of that value -> `a` -> "a", `+` -> "+", `-` -> "-"
+    - interpret it as a special key (Space, Enter, Shift, Alt, Ctrl etc.), still initially store it as a string
+    but adds a Key suffix e.g. "Key.Enter".
+    -  numpad keys which become become strings from "<96>" (numpad1) to "<105>" (numpad9)
+- save string into a hotkeys.txt file in custom `value = key` syntax
+
+Here the main issue is character literals: keyboards can output different value when key at same position is pressed. For example
+- Nordic and US keyboards => `-` outputs `-`
+- German keyboard => `-` outputs `/`
+
+**Why this (possibly) breaks hotkeys:**  
+Bot uses Python libraries which innately default to US-centric which would also produce the "-" and this same value is now the output. So when user with german keyboard system attempts to input `/`, bot saves this as "-" BUT Bloons TD 6 game still excepts the "/". So the chain becomes
+
+> User sets hotkey "/" -> bot converts this to "-" -> game still expects "/", but instead receives "-"
+
+Fixing this system would require some larger changes in code base. While annoying, this is not a critical issue and won't prevent bot from running. It will be fixed at some point in the future, but **there's no estimated time of arrival for this yet**.
+
+**Temporary fix (until hotkey system gets overhauled)**  
+If your hotfix doesn't map properly, you can edit the hotkeys file directly in `btd6bot/btd6bot/Files/text files/hotkeys.txt`. Simply change the right side of hotkey and save file. For example:
+- you use german keyboard layout and want to replace the default `-` value for bottom path upgrades to match `/`
+- just like above, pressing `-` on a german keyboard results in just `-` again
+- so instead open the file hotkeys.txt file, find the line `upgrade bot = -` and change this to `upgrade bot = /`
+- save the file
+
+And you're good to go.
 
 
 #### [Future updates]
@@ -118,6 +158,7 @@ Will mostly depend on what features/changes BTD6 does. For bot this usually mean
 Since bot has reached version 1.0.0, it's unlikely any major features gets added.  
 Some possible ones **with no specific ETA:**
 - project code/structure changes:
+    - update hotkey system from string chars to keycodes (this would prevent issues with different keyboard language systems)
     - update plans directory structure by adding subdirectories for each map
     - use a proper plan file format like yaml/toml/json instead of python files. Would require a major rework of the codebase, but also make writing plans much easier.
     - go over entire codebase and see if there's anything that absolutely needs to be updated/reworked
@@ -1229,7 +1270,7 @@ Btd6 main menu screen. After menu screen is found, bot then begins it's current 
 
     >Most settings (like resolution) and hotkey values, are updated immediately to current monitoring window. But any
     toggleable modes and current plan list, will only get updated after you close and reopen this window.
-    If you want to be 100% certain your setting are up to date after any changes, just close and reopen monitoring
+    If you want to be 100% certain, just close and reopen monitoring
     window each time you have made changes to settings.
 
 - Has a output window where all printed text is redirected during bot runtime. This way, it's easy to follow what
@@ -1356,51 +1397,53 @@ remained the same ever since:
 Now, open your plan file. It looks like this:
 
 
-    """  
-    [Hero] -
-    [Monkey Knowledge] -
-    -------------------------------------------------------------
-    ===Monkeys & upgrades required===
-    _______________________________________
-    """
+```python 
+"""
+[Hero] -
+[Monkey Knowledge] -
+-------------------------------------------------------------
+===Monkeys & upgrades required===
+_______________________________________
+"""
 
-    '''
-    from ._plan_imports import *
+'''
+from ._plan_imports import *
 
 
-    def play(data):
-        BEGIN, END = menu_start.load(*data)
-        round = BEGIN - 1
-        map_start = time()
-        while round < END + 1:
-            round = Rounds.round_check(round, map_start, data[2])
-            if round == BEGIN:
-                ...
-    '''
->
+def play(data):
+    BEGIN, END = menu_start.load(*data)
+    round = BEGIN - 1
+    map_start = time()
+    while round < END + 1:
+        round = Rounds.round_check(round, map_start, data[2])
+        if round == BEGIN:
+            ...
+'''
+```
 
 First remove the two comment lines starting with ''' symbols (not the """) so bot is able to execute plan code:
 
-    """  
-    [Hero]  
-    [Monkey Knowledge] -
-    -------------------------------------------------------------
-    ===Monkeys & upgrades required===
-    _______________________________________
-    """
+```python
+"""  
+[Hero]  
+[Monkey Knowledge] -
+-------------------------------------------------------------
+===Monkeys & upgrades required===
+_______________________________________
+"""
 
-    from._plan_imports import *
+from._plan_imports import *
 
 
-    def play(data):
-        BEGIN, END = menu_start.load(*data)
-        round = BEGIN - 1
-        map_start = time()
-        while round < END + 1:
-            round = Rounds.round_check(round, map_start, data[2])
-            if round == BEGIN:
-                ...
->
+def play(data):
+    BEGIN, END = menu_start.load(*data)
+    round = BEGIN - 1
+    map_start = time()
+    while round < END + 1:
+        round = Rounds.round_check(round, map_start, data[2])
+        if round == BEGIN:
+            ...
+```
 
 This is about the minimal code needed to run a plan file. To quickly summarize what's in here:
 
@@ -1451,7 +1494,7 @@ for current plan: it will be displayed both under main and queue windows. It con
         row.
 
     With sections 1.-4. combined, here's a simple info text example:
-  
+
         [Hero] Quincy
         [Monkey Knowledge] -
         -------------------------------------------------------------
@@ -1478,16 +1521,18 @@ for current plan: it will be displayed both under main and queue windows. It con
 
 Now that you know what the info panel is, let us have a look at the main body:
 
-    from._plan_imports import *
+```python
+from._plan_imports import *
 
-    def play(data):
-        BEGIN, END = menu_start.load(*data)
-        round = BEGIN - 1
-        map_start = time()
-        while round < END + 1:
-            round = Rounds.round_check(round, map_start, data[2])
-            if round == BEGIN:
-                ...
+def play(data):
+    BEGIN, END = menu_start.load(*data)
+    round = BEGIN - 1
+    map_start = time()
+    while round < END + 1:
+        round = Rounds.round_check(round, map_start, data[2])
+        if round == BEGIN:
+            ...
+```
 
 This block is Python code. It includes
 
@@ -1501,41 +1546,50 @@ this to corresponding if/elif block to perform command for that round.
 
 Thus, you only need to interact with the part starting from
     
-        if round == BEGIN:
-            ...
+```python
+    if round == BEGIN:
+        ...
+```
 
 Note that BEGIN is a variable: <u>YOU DON'T NEED TO CHANGE THIS VALUE</u>, it will always stand for first round.
 
 Usually you have multiple rounds which means rounds look like this:
 
-        if round == BEGIN:
-            ...
-        elif round == 7:
-            ...
-        elif round == 10:
-        .
-        .
-        .
-        elif round == 99:
-            ...
+```python
+    if round == BEGIN:
+        ...
+    elif round == 7:
+        ...
+    elif round == 10:
+    .
+    .
+    .
+    elif round == 99:
+        ...
+```
 
 Previous block could serve as chimps mode plan template: here BEGIN stands for 6. Note that if nothing happens during a
 round, you can exclude it from if/elif: here rounds 8 and 9 are skipped over. For final round you can just use the round
 number or variable END:
         
-        elif round == 100:
-            ...
+```python
+    elif round == 100:
+        ...
 
-        # or
+    # or
 
-        elif round == END:
-            ...
+    elif round == END:
+        ...
+```
+
 Again, no need to include final round block if it has no commands.
 
 On two special cases, you can just use the first if-block
 
-        if round == BEGIN:
-            ...
+```python
+    if round == BEGIN:
+        ...
+```
 to include all commands. These are deflation and apopalypse. In fact, for apopalypse, you 
 **have to use only the first round block!**. After first round ends, bot sets internal flag for end round and stops
 processing other rounds.
@@ -1785,19 +1839,25 @@ execution.
     can be placed normally, but cannot be clicked and accesed again at same location. Thus following commands are 
     performed:
 
+    ```python
         sniper3 = Monkey("sniper", 0.1619791666667, 0.0268518518519, placement_check=False)
         sniper3.target("strong", cpos=(0.1291666666667, 0.0601851851852))
+    ```
     
     Here, as you can see, sniper ignores the placement check, and next target command updates the (x,y) position of 
     sniper by moving slightly left and up from initial x and y coordinates.
 
 - [**Order of arguments**] In command examples, commands often exclude the argument names. For example
 
+    ```python
         dart = Monkey("dart", 0.5, 0.5)
+    ```
 
     is the same as
 
+    ```python
         dart = Monkey(name="dart", pos_x=0.5, pos_y=0.5)
+    ```
     
     Reason is, **if you use arguments in order**, `arg_name=` syntax is not needed: Python knows that, in above 
     example, `"dart"` refers to argument `name`, the first `0.5` value refers to `pos_x` and second to 
@@ -1810,7 +1870,9 @@ execution.
     cpos argument is needed. Now, target command has syntax `target(set_target, x, y, cpos)` 
     which means if you write
 
+    ```python
         dart.target("strong", 0.45, 0.3)
+    ```
     
     this will actually just click dart's current internal location (0.5, 0.5) and try to set monkey at that location
     on "strong". Well there could be a monkey, or not. Nontheless, it's not the intended outcome! After 
@@ -1819,19 +1881,27 @@ execution.
 
     The problem? Just as stated at the first example, this argument means
 
+    ```python
         dart.target("strong", pos_x=0.45, pos_y=0.3)
+    ```
 
     Because x and y values are not needed for dart, command needs to be provided with argument names:
 
+    ```python
         dart.target("strong", cpos=(0.45, 0.3))
+    ```
 
     This would do what we originally wanted. Of course, something like
 
+    ```python
         dart.target("strong", 0.2, 0.3, 0.45, 0.3)
+    ```
 
     would also work in sense, because it does the same as
 
+    ```python
         dart.target("strong", pos_x=0.2, pos_y=0.3, cpos=(0.45, 0.3))
+    ```
     
     but again bot would set the target location of 0-0-0 dart at (0.2, 0.3). Luckily, it would cause no harm, but is 
     not what was intended.
@@ -2012,6 +2082,7 @@ So only files you likely need to modify are
 
     Example: if your monkey is called `"test_monkey"` and it belongs to military category, then code becomes
 
+    ```python
         _MONKEY_NAMES = (
         "dart",  # primary
         "boomer",
@@ -2041,8 +2112,9 @@ So only files you likely need to modify are
         "beast",
         "hero",  # hero
     )
+    ```
 
-    **Don't forget to add comma `,` at the end of each row, except the last "hero" row!**
+    **Don't forget to add comma `,` at the end of each row!**
 
 2. **Set hotkey**
 
@@ -2057,8 +2129,10 @@ So only files you likely need to modify are
 
     - in `bot/commands/monkeys.py`, search `_get_hotkey` and support for new hotkey:
 
-            case "test_monkey":
-                return hotkeys["test monkey"]
+        ```python
+        case "test_monkey":
+            return hotkeys["test monkey"]
+        ```
 
     Here, 
     
@@ -2086,8 +2160,10 @@ So only files you likely need to modify are
     - in `monkeys.py`, search `_update_auto_target_paths`
     - then simply add a new line like this:
 
-            if self._name == "test_monkey" and i == 0 and int(u[2*i]) == 4:
-                self._targeting = "strong"
+        ```python
+        if self._name == "test_monkey" and i == 0 and int(u[2*i]) == 4:
+            self._targeting = "strong"
+        ```
     
     Here, 
     
@@ -2183,29 +2259,31 @@ This in in fact the only mandatory step for adding heroes. However, if hero uses
     - search for method `_change_hero_target` and find following part (or something that looks very similar to it in 
     case this has not been updated) under it:
 
-            match self._hero_name:
-                case "benjamin":
-                    print("???")
-                case "etienne":
-                    if target == "d&q":
-                        if current == "first":
-                            kb_mouse.kb_input(hotkeys["target change"])
-                        elif current == "zone":
-                            kb_mouse.kb_input(hotkeys["target reverse"])
-                    elif target == "first":
-                        if current == "d&q":
-                            kb_mouse.kb_input(hotkeys["target reverse"])
-                        elif current == "zone":
-                            kb_mouse.kb_input(hotkeys["target change"])
-                    elif target == "zone":
-                        if current == "first":
-                            kb_mouse.kb_input(hotkeys["target reverse"])
-                        elif current == "d&q":
-                            kb_mouse.kb_input(hotkeys["target change"])
-                    else:
-                        return self._name, target
-                case _:
-                    return self._normal_targeting(current, target) 
+        ```python
+        match self._hero_name:
+            case "benjamin":
+                print("???")
+            case "etienne":
+                if target == "d&q":
+                    if current == "first":
+                        kb_mouse.kb_input(hotkeys["target change"])
+                    elif current == "zone":
+                        kb_mouse.kb_input(hotkeys["target reverse"])
+                elif target == "first":
+                    if current == "d&q":
+                        kb_mouse.kb_input(hotkeys["target reverse"])
+                    elif current == "zone":
+                        kb_mouse.kb_input(hotkeys["target change"])
+                elif target == "zone":
+                    if current == "first":
+                        kb_mouse.kb_input(hotkeys["target reverse"])
+                    elif current == "d&q":
+                        kb_mouse.kb_input(hotkeys["target change"])
+                else:
+                    return self._name, target
+            case _:
+                return self._normal_targeting(current, target)
+        ```
 
         Here the special cases: all other heroes operate under basic system. 
         

--- a/README.md
+++ b/README.md
@@ -1192,9 +1192,7 @@ it.
     [this section](#any-aspect-ratio) of advanced resolutions guide.
 
 - **Ocr time limit**: How long will bot attempt to search for various text flags before it gives up and attempts to
-return to main menu. Typically, this should never occur so a high value of 300 seconds or more is recommended: this 
-is especially important for apopalypse plans as in those you can have long periods of downtime where bot attempts to 
-place/upgrade a monkey.
+return to main menu. Typically, this should never occur so a high value of 300 seconds or more is recommended
 
 - **Ocr frequency**: Pause interval between most ocr operations, in seconds. Naturally every operation has base cost
 which depends on cpu/gpu speed on top of which this value is then added. Raising this value will greatly decrease 
@@ -1584,17 +1582,25 @@ number or variable END:
 
 Again, no need to include final round block if it has no commands.
 
-On two special cases, you can just use the first if-block
+On a special case, you can just use the first if-block
 
 ```python
     if round == BEGIN:
         ...
 ```
-to include all commands. These are deflation and apopalypse. In fact, for apopalypse, you 
-**have to use only the first round block!**. After first round ends, bot sets internal flag for end round and stops
-processing other rounds.
+to include all commands. This is used in **deflation mode**, but you could technically use this on every single game
+mode.
+- If you do end using this on **non-deflation game modes (= don't use this on deflation plans!)**, for example in apopalypse because you can't bother tracking each round (understandable because pausing is disabled), you should **ALWAYS** write
+
+    ```python
+        round = END
+    ```
+
+  as the very final command, setting bot's round tracking to last round. This avoids the issue with executing all commands on BEGIN round and then waiting bot to skip over all the rounds between BEGIN and END, printing lots of empty rounds.  
+  More importantly, without round = END, while bot is catching up in rounds, game actually finishes. This results the background becoming darker which makes round reading pretty much impossible, leaving bot to hang until ocr time limit is reached (and even with that bot might fail to leave end screen, requiring user to manually reset the state).
+
     
-For examples see *dark_castleEasyDeflation.py* and *infernalMediumApopalypse.py* plan files.
+For examples see *dark_castleEasyDeflation.py* and also *infernalMediumApopalypse.py* where the latter uses only BEGIN round block and thus includes the "round = END".
 
 
 ## **Commands**

--- a/_install/INSTALL.md
+++ b/_install/INSTALL.md
@@ -34,7 +34,9 @@ user. You can do this by issuing the following PowerShell command:
 => This means Windows users might need to run following command in powershell in order to allow use of virtual 
 environments:
 
-    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
 
 
 ### Linux
@@ -179,77 +181,103 @@ reside under
 
 #### install.bat
 
-    powershell -NoProfile -Command ^
+```powershell
+powershell -NoProfile -Command ^
+```
 
 Executes script in powershell without loading user's profile (e.g. Microsoft or powershell profile file)
 
-    Invoke-WebRequest 'https://github.com/j-miet/BTD6bot/archive/refs/heads/main.zip' -Outfile './main.zip' ^
+```powershell
+Invoke-WebRequest 'https://github.com/j-miet/BTD6bot/archive/refs/heads/main.zip' -Outfile './main.zip' ^
+```
 
 Sends a web request to BTD6bot github project url to retrieve data from main branch as a zip file, then downloads this 
 zip and saves it in './main.zip' i.e. current script run directory. So if your install.bat is located in 
 'C:/your/path/install.bat' then zip file becomes 'C:/your/path/main.zip'
 
-    if (Test-Path ./BTD6bot-main) { ^
+```powershell
+if (Test-Path ./BTD6bot-main) { ^
 
-    Remove-Item './BTD6bot-main' -Recurse -Force -Confirm:$false ^
+Remove-Item './BTD6bot-main' -Recurse -Force -Confirm:$false ^
 
-    } ^
+} ^
+```
 
 Checks if previous BTD6bot-main directory exists in script run directory. If yes, **delete entire directory**.
 
-    Expand-Archive -Path './main.zip' -DestinationPath '.' ^
+```powershell
+Expand-Archive -Path './main.zip' -DestinationPath '.' ^
+```
 
 Unzips the main.zip into current directory. Github names the project directory as {project_name}-{branch} -> this 
 means after unzip, bot files are located in C:/your/path/BTD6bot-main
 
-    Remove-Item './main.zip' ^
+```powershell
+Remove-Item './main.zip' ^
+```
 
 After unzip auto-delete the zip file
 
-    Set-Location "./BTD6bot-main/" ^
+```powershell
+Set-Location "./BTD6bot-main/" ^
+```
 
 Change current directory location inside bot dir
 
-    Copy-Item './_install/win/_copy/run.bat' -Destination './run.bat' ^
+```powershell
+Copy-Item './_install/win/_copy/run.bat' -Destination './run.bat' ^
+```
 
 Copies run.bat scripts from _install directory so it can be found in c:/your/path/BTD6bot-main/run.bat.
 
-    Copy-Item './_install/win/_copy/run-nogui.bat' -Destination './run-nogui.bat' ^
+```powershell
+Copy-Item './_install/win/_copy/run-nogui.bat' -Destination './run-nogui.bat' ^
+```
 
 Like before, copies the no-gui.bat script into root dir
 
-    Copy-Item './_install/win/_copy/show_coordinates.bat' -Destination './tools/show_coordinates/run.bat' ^
+```powershell
+Copy-Item './_install/win/_copy/show_coordinates.bat' -Destination './tools/show_coordinates/run.bat' ^
 
-    Copy-Item './_install/win/_copy/move_mouse.bat' -Destination './tools/move_mouse/run.bat' ^
+Copy-Item './_install/win/_copy/move_mouse.bat' -Destination './tools/move_mouse/run.bat' ^
 
-    Copy-Item './_install/win/_copy/image_scaler.bat' -Destination './tools/image_scaler/run.bat' ^
+Copy-Item './_install/win/_copy/image_scaler.bat' -Destination './tools/image_scaler/run.bat' ^
 
-    Copy-Item './_install/win/_copy/command_tracker.bat' -Destination './tools/command_tracker/run.bat' ^
+Copy-Item './_install/win/_copy/command_tracker.bat' -Destination './tools/command_tracker/run.bat' ^
+```
 
 These commands copy tooling scripts into their respective dirs under 
 c:/your/path/BTD6bot-main/tools/tool_name/tool_name.bat
 
-    python -m venv ./.venv ^
+```powershell
+python -m venv ./.venv ^
+```
 
 Setup a python virtual environment so all packages from requirements.txt are installed locally and don't interfere with 
 global package space. Virtual environment files are found under c:/your/path/BTD6bot-main/.venv
 
-    ./.venv/Scripts/activate ^
+```powershell
+./.venv/Scripts/activate ^
+```
 
 Activate virtual environment
 
-    pip install -r requirements.txt
+```powershell
+pip install -r requirements.txt
+```
 
 Install required external packages listed in requirements.txt. Because virtual environment is activated, these packages 
 are installed locally under c:/your/path/BTD6bot-main/.venv/Lib/site-packages
 
 #### Other .bat scripts (located in win/_copy directory)
 
-    powershell -NoProfile -Command ^
+```powershell
+powershell -NoProfile -Command ^
 
-    ./.venv/Scripts/activate ^
+./.venv/Scripts/activate ^
 
-    python btd6bot
+python btd6bot
+```
 
 These all follow similar pattern:
 1. run script in powershell without a user profile
@@ -264,56 +292,76 @@ These all follow similar pattern:
 
 #### install.sh
 
-    #!/usr/bin/env bash
+```bash
+#!/usr/bin/env bash
+```
 
 Search your PATH, find bash executable then run script with this bash version
 
-    curl -OL https://github.com/j-miet/BTD6bot/archive/refs/heads/main.zip
+```bash
+curl -OL https://github.com/j-miet/BTD6bot/archive/refs/heads/main.zip
+```
 
 Client url command sends request to download main.zip from BTD6bot github archive. Here -O means zip is saved with its 
 original name 'main.zip', -L allows server redirects if main.zip cannot be downloaded directly from that github link. 
 File will be downloaded into current working directory e.g. your path which could be c:/your/path. So running 
 c:/your/path/install.sh results in c:/your/path/main.zip
 
-    unzip main.zip
+```bash
+unzip main.zip
+```
 
 Unzips main.zip contents into 'c:/your/path/BTD6bot-main' directory. Github defaults directory names to 
 {project_name}-{branch} which is why it becomes 'BTD6bot-main'
 
-    rm main.zip
+```bash
+rm main.zip
+```
 
 After unzip, auto-remove zip file
 
-    cd ./BTD6bot-main/
+```bash
+cd ./BTD6bot-main/
+```
 
 Change working directory to BTD6bot install folder
 
-    cp ./_install/other/_copy/run.sh ./run.sh
-    cp ./_install/other/_copy/run-nogui.sh ./run-nogui.sh
+```bash
+cp ./_install/other/_copy/run.sh ./run.sh
+cp ./_install/other/_copy/run-nogui.sh ./run-nogui.sh
+```
 
 Copy bot running scripts (gui and without gui) into bot root folder
 
-    cp ./_install/other/_copy/show_coordinates.sh ./tools/show_coordinates/run.sh
-    cp ./_install/other/_copy/move_mouse.sh ./tools/move_mouse/run.sh
-    cp ./_install/other/_copy/image_scaler.sh ./tools/image_scaler/run.sh
-    cp ./_install/other/_copy/command_tracker.sh ./tools/command_tracker/run.sh
+```bash
+cp ./_install/other/_copy/show_coordinates.sh ./tools/show_coordinates/run.sh
+cp ./_install/other/_copy/move_mouse.sh ./tools/move_mouse/run.sh
+cp ./_install/other/_copy/image_scaler.sh ./tools/image_scaler/run.sh
+cp ./_install/other/_copy/command_tracker.sh ./tools/command_tracker/run.sh
+```
 
 For tool scripts, copy them into their respective tool directories under c:/your/path/BTD6bot-main/tools
 
-    python3 -m venv ./.venv
+```bash
+python3 -m venv ./.venv
+```
 
 Setup a virtual environment so all external packages are installed locally under c:/your/path/BTD6bot-main/.venv dir 
 and don't interfere with global package space
 
-    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
-        source ./.venv/Scripts/activate
-    else
-        source ./.venv/bin/activate
-    fi
+```bash
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    source ./.venv/Scripts/activate
+else
+    source ./.venv/bin/activate
+fi
+```
 
 Activate virtual environment. If operating system is Windows (msys/cygwin), use first path. If not, use second path.
 
-    pip3 install -r requirements.txt
+```bash
+pip3 install -r requirements.txt
+```
 
 In current virtual environment, install external packages listed in requirements.txt. These can then be found in 
 c:/your/path/BTD6bot-main/.venv/Lib/site-packages
@@ -321,13 +369,15 @@ c:/your/path/BTD6bot-main/.venv/Lib/site-packages
 
 #### Other .sh scripts (located in other/_copy directory)
 
-    #!/usr/bin/env bash
-    if [[ "$OSTYPE" == "msys" ]]; then
-        source ./.venv/Scripts/activate
-    else
-        source ./.venv/bin/activate
-    fi
-    python3 btd6bot
+```bash
+#!/usr/bin/env bash
+if [[ "$OSTYPE" == "msys" ]]; then
+    source ./.venv/Scripts/activate
+else
+    source ./.venv/bin/activate
+fi
+python3 btd6bot
+```
 
 These all follow similar pattern:
 1. run file using bash

--- a/btd6bot/Files/helpwindow/README.md
+++ b/btd6bot/Files/helpwindow/README.md
@@ -34,7 +34,7 @@ section.
 ---
 #### [Update status]
 
-- Latest version of bot is **1.0.0** which matches BTD6's *Update 54*. 
+- Latest version of bot is **1.0.2** which matches BTD6's *Update 54*. 
 
     => Release notes can be found [here](https://github.com/j-miet/BTD6bot/releases/tag/v1.0.0)
     - For now, bot is planned to be updated after each major game update. These **updates** are marked as `1.X.0`
@@ -45,7 +45,7 @@ section.
 
     => Plans were previously updated in **1.0.0**. Next update cycle is scheduled for **1.2.0**.
 
-    - <u>Main goal is to keep all Chimps plans updated and add any missing ones</u>. This process is repeated 
+    - <u>Main goal is to keep all Chimps plans available and updated</u>. This process is repeated 
     **every 2-3 updates**. Other plans could stay untested for extended periods of time, but then again, are also less 
     affected by tower balancing/price changes.
 
@@ -82,14 +82,19 @@ all of them. Currently:
     - **Debian 13.4 (GNOME on Xorg)**
     - **Linux Arch (Wayland with Hyprland)**
     
-    At least gui, kb+mouse automation, and ocr functions have been tested on these distros which means bot should operate just fine.
+    At least gui, kb+mouse automation, and ocr functions have been tested on these distros which means bot should 
+    operate just fine.
 
-    => In general, **bot supports X11 or wlroots-based displays.** If your system has one of these available, you should be able to run the bot even if it's not listed above. How these relate to tested distros:
+    => In general, **bot supports X11 or wlroots-based displays.** If your system has one of these available, you 
+    should be able to run the bot even if it's not listed above. How these relate to tested distros:
     - Linux Mint uses X11
-    - Debian GNOME uses *GNOME Wayland* by default, which is based on KDE. This on itself will not work, but you can easily switch to *GNOME on Xorg* which uses X11
-    - Hyprland uses it's custom *aquamarine* compositor for Wayland which also retains wlroots compatibility.
+    - Debian GNOME uses *GNOME Wayland* by default, which intentionally limits screenshots to be 
+    interactive/user-controlled, preventing code-level access. However you can easily switch to *GNOME on Xorg* which 
+    uses X11
+    - Hyprland uses it's custom *aquamarine* compositor for Wayland which also retains wlroots compatibility
     
-    For more info, see [this section](_install/INSTALL.md#linux) of the install guide. It will used as a reference later and explains the X11/Wayland compatibility in more detail.
+    For more info, see [this section](_install/INSTALL.md#linux) of the install guide. It will used as a reference 
+    later and explains the X11/Wayland compatibility in more detail.
 
 - **MacOS => Not supported, but could still work** 
 
@@ -99,14 +104,49 @@ all of them. Currently:
     - some code-level testing has been done using VirtualBox on much older versions (Catalina, Big Sur):
         - custom gui-only hotkeys are disabled for Mac systems. Reason is Python libraries used for gui and 
         hotkeys (`tkinter` & `pynput` respectively) interfere with each other due to them running on same main thread. 
-        Thus hotkeys must be typed manually. Also bot can be still halted without hotkeys by quickly dragging mouse cursor to upper-left corner.
+        Thus hotkeys must be typed manually. Also bot can be still halted without hotkeys by quickly dragging mouse 
+        cursor to upper-left corner.
         - mac uses `16:10` aspect ratio as a baseline and lacks the support for recommended `16:9` resolutions. Again, 
     this can probably be fixed by using the tricks explained above in resolution section.
-        - if using running the bot inside gui doesn't work, you can use the no-gui version of bot. You can still use gui to update settings, hotkeys and plan queue, then close gui and switch to no-gui version.
+        - if using running the bot inside gui doesn't work, you can use the no-gui version of bot. You can still use 
+        gui to update settings, hotkeys and plan queue, then close gui and switch to no-gui version.
 
 The only *"OS-independent solution"* would be a dual boot setup: install a separate Windows version/widely supported 
 Linux distribution, then run btd6 + bot in this environment.
 - Don't try to use virtual machine. These cannot properly utilize GPU which makes your game run on extremely low fps.
+
+#### [Keyboard languages]
+
+There's an issue with keyboard value conversion with different input languages on keyboard. This reason is current system stores values in strings instead of keycodes.
+
+Current saving process:
+- user gives input
+- input is parsed. This can happen in three ways:
+    - store a character literal of that value -> `a` -> "a", `+` -> "+", `-` -> "-"
+    - interpret it as a special key (Space, Enter, Shift, Alt, Ctrl etc.), still initially store it as a string
+    but adds a Key suffix e.g. "Key.Enter".
+    -  numpad keys which become become strings from "<96>" (numpad1) to "<105>" (numpad9)
+- save string into a hotkeys.txt file in custom `value = key` syntax
+
+Here the main issue is character literals: keyboards can output different value when key at same position is pressed. For example
+- Nordic and US keyboards => `-` outputs `-`
+- German keyboard => `-` outputs `/`
+
+**Why this (possibly) breaks hotkeys:**  
+Bot uses Python libraries which innately default to US-centric which would also produce the "-" and this same value is now the output. So when user with german keyboard system attempts to input `/`, bot saves this as "-" BUT Bloons TD 6 game still excepts the "/". So the chain becomes
+
+> User sets hotkey "/" -> bot converts this to "-" -> game still expects "/", but instead receives "-"
+
+Fixing this system would require some larger changes in code base. While annoying, this is not a critical issue and won't prevent bot from running. It will be fixed at some point in the future, but **there's no estimated time of arrival for this yet**.
+
+**Temporary fix (until hotkey system gets overhauled)**  
+If your hotfix doesn't map properly, you can edit the hotkeys file directly in `btd6bot/btd6bot/Files/text files/hotkeys.txt`. Simply change the right side of hotkey and save file. For example:
+- you use german keyboard layout and want to replace the default `-` value for bottom path upgrades to match `/`
+- just like above, pressing `-` on a german keyboard results in just `-` again
+- so instead open the file hotkeys.txt file, find the line `upgrade bot = -` and change this to `upgrade bot = /`
+- save the file
+
+And you're good to go.
 
 
 #### [Future updates]
@@ -118,6 +158,7 @@ Will mostly depend on what features/changes BTD6 does. For bot this usually mean
 Since bot has reached version 1.0.0, it's unlikely any major features gets added.  
 Some possible ones **with no specific ETA:**
 - project code/structure changes:
+    - update hotkey system from string chars to keycodes (this would prevent issues with different keyboard language systems)
     - update plans directory structure by adding subdirectories for each map
     - use a proper plan file format like yaml/toml/json instead of python files. Would require a major rework of the codebase, but also make writing plans much easier.
     - go over entire codebase and see if there's anything that absolutely needs to be updated/reworked
@@ -1229,7 +1270,7 @@ Btd6 main menu screen. After menu screen is found, bot then begins it's current 
 
     >Most settings (like resolution) and hotkey values, are updated immediately to current monitoring window. But any
     toggleable modes and current plan list, will only get updated after you close and reopen this window.
-    If you want to be 100% certain your setting are up to date after any changes, just close and reopen monitoring
+    If you want to be 100% certain, just close and reopen monitoring
     window each time you have made changes to settings.
 
 - Has a output window where all printed text is redirected during bot runtime. This way, it's easy to follow what
@@ -1356,51 +1397,53 @@ remained the same ever since:
 Now, open your plan file. It looks like this:
 
 
-    """  
-    [Hero] -
-    [Monkey Knowledge] -
-    -------------------------------------------------------------
-    ===Monkeys & upgrades required===
-    _______________________________________
-    """
+```python 
+"""
+[Hero] -
+[Monkey Knowledge] -
+-------------------------------------------------------------
+===Monkeys & upgrades required===
+_______________________________________
+"""
 
-    '''
-    from ._plan_imports import *
+'''
+from ._plan_imports import *
 
 
-    def play(data):
-        BEGIN, END = menu_start.load(*data)
-        round = BEGIN - 1
-        map_start = time()
-        while round < END + 1:
-            round = Rounds.round_check(round, map_start, data[2])
-            if round == BEGIN:
-                ...
-    '''
->
+def play(data):
+    BEGIN, END = menu_start.load(*data)
+    round = BEGIN - 1
+    map_start = time()
+    while round < END + 1:
+        round = Rounds.round_check(round, map_start, data[2])
+        if round == BEGIN:
+            ...
+'''
+```
 
 First remove the two comment lines starting with ''' symbols (not the """) so bot is able to execute plan code:
 
-    """  
-    [Hero]  
-    [Monkey Knowledge] -
-    -------------------------------------------------------------
-    ===Monkeys & upgrades required===
-    _______________________________________
-    """
+```python
+"""  
+[Hero]  
+[Monkey Knowledge] -
+-------------------------------------------------------------
+===Monkeys & upgrades required===
+_______________________________________
+"""
 
-    from._plan_imports import *
+from._plan_imports import *
 
 
-    def play(data):
-        BEGIN, END = menu_start.load(*data)
-        round = BEGIN - 1
-        map_start = time()
-        while round < END + 1:
-            round = Rounds.round_check(round, map_start, data[2])
-            if round == BEGIN:
-                ...
->
+def play(data):
+    BEGIN, END = menu_start.load(*data)
+    round = BEGIN - 1
+    map_start = time()
+    while round < END + 1:
+        round = Rounds.round_check(round, map_start, data[2])
+        if round == BEGIN:
+            ...
+```
 
 This is about the minimal code needed to run a plan file. To quickly summarize what's in here:
 
@@ -1451,7 +1494,7 @@ for current plan: it will be displayed both under main and queue windows. It con
         row.
 
     With sections 1.-4. combined, here's a simple info text example:
-  
+
         [Hero] Quincy
         [Monkey Knowledge] -
         -------------------------------------------------------------
@@ -1478,16 +1521,18 @@ for current plan: it will be displayed both under main and queue windows. It con
 
 Now that you know what the info panel is, let us have a look at the main body:
 
-    from._plan_imports import *
+```python
+from._plan_imports import *
 
-    def play(data):
-        BEGIN, END = menu_start.load(*data)
-        round = BEGIN - 1
-        map_start = time()
-        while round < END + 1:
-            round = Rounds.round_check(round, map_start, data[2])
-            if round == BEGIN:
-                ...
+def play(data):
+    BEGIN, END = menu_start.load(*data)
+    round = BEGIN - 1
+    map_start = time()
+    while round < END + 1:
+        round = Rounds.round_check(round, map_start, data[2])
+        if round == BEGIN:
+            ...
+```
 
 This block is Python code. It includes
 
@@ -1501,41 +1546,50 @@ this to corresponding if/elif block to perform command for that round.
 
 Thus, you only need to interact with the part starting from
     
-        if round == BEGIN:
-            ...
+```python
+    if round == BEGIN:
+        ...
+```
 
 Note that BEGIN is a variable: <u>YOU DON'T NEED TO CHANGE THIS VALUE</u>, it will always stand for first round.
 
 Usually you have multiple rounds which means rounds look like this:
 
-        if round == BEGIN:
-            ...
-        elif round == 7:
-            ...
-        elif round == 10:
-        .
-        .
-        .
-        elif round == 99:
-            ...
+```python
+    if round == BEGIN:
+        ...
+    elif round == 7:
+        ...
+    elif round == 10:
+    .
+    .
+    .
+    elif round == 99:
+        ...
+```
 
 Previous block could serve as chimps mode plan template: here BEGIN stands for 6. Note that if nothing happens during a
 round, you can exclude it from if/elif: here rounds 8 and 9 are skipped over. For final round you can just use the round
 number or variable END:
         
-        elif round == 100:
-            ...
+```python
+    elif round == 100:
+        ...
 
-        # or
+    # or
 
-        elif round == END:
-            ...
+    elif round == END:
+        ...
+```
+
 Again, no need to include final round block if it has no commands.
 
 On two special cases, you can just use the first if-block
 
-        if round == BEGIN:
-            ...
+```python
+    if round == BEGIN:
+        ...
+```
 to include all commands. These are deflation and apopalypse. In fact, for apopalypse, you 
 **have to use only the first round block!**. After first round ends, bot sets internal flag for end round and stops
 processing other rounds.
@@ -1785,19 +1839,25 @@ execution.
     can be placed normally, but cannot be clicked and accesed again at same location. Thus following commands are 
     performed:
 
+    ```python
         sniper3 = Monkey("sniper", 0.1619791666667, 0.0268518518519, placement_check=False)
         sniper3.target("strong", cpos=(0.1291666666667, 0.0601851851852))
+    ```
     
     Here, as you can see, sniper ignores the placement check, and next target command updates the (x,y) position of 
     sniper by moving slightly left and up from initial x and y coordinates.
 
 - [**Order of arguments**] In command examples, commands often exclude the argument names. For example
 
+    ```python
         dart = Monkey("dart", 0.5, 0.5)
+    ```
 
     is the same as
 
+    ```python
         dart = Monkey(name="dart", pos_x=0.5, pos_y=0.5)
+    ```
     
     Reason is, **if you use arguments in order**, `arg_name=` syntax is not needed: Python knows that, in above 
     example, `"dart"` refers to argument `name`, the first `0.5` value refers to `pos_x` and second to 
@@ -1810,7 +1870,9 @@ execution.
     cpos argument is needed. Now, target command has syntax `target(set_target, x, y, cpos)` 
     which means if you write
 
+    ```python
         dart.target("strong", 0.45, 0.3)
+    ```
     
     this will actually just click dart's current internal location (0.5, 0.5) and try to set monkey at that location
     on "strong". Well there could be a monkey, or not. Nontheless, it's not the intended outcome! After 
@@ -1819,19 +1881,27 @@ execution.
 
     The problem? Just as stated at the first example, this argument means
 
+    ```python
         dart.target("strong", pos_x=0.45, pos_y=0.3)
+    ```
 
     Because x and y values are not needed for dart, command needs to be provided with argument names:
 
+    ```python
         dart.target("strong", cpos=(0.45, 0.3))
+    ```
 
     This would do what we originally wanted. Of course, something like
 
+    ```python
         dart.target("strong", 0.2, 0.3, 0.45, 0.3)
+    ```
 
     would also work in sense, because it does the same as
 
+    ```python
         dart.target("strong", pos_x=0.2, pos_y=0.3, cpos=(0.45, 0.3))
+    ```
     
     but again bot would set the target location of 0-0-0 dart at (0.2, 0.3). Luckily, it would cause no harm, but is 
     not what was intended.
@@ -2012,6 +2082,7 @@ So only files you likely need to modify are
 
     Example: if your monkey is called `"test_monkey"` and it belongs to military category, then code becomes
 
+    ```python
         _MONKEY_NAMES = (
         "dart",  # primary
         "boomer",
@@ -2041,8 +2112,9 @@ So only files you likely need to modify are
         "beast",
         "hero",  # hero
     )
+    ```
 
-    **Don't forget to add comma `,` at the end of each row, except the last "hero" row!**
+    **Don't forget to add comma `,` at the end of each row!**
 
 2. **Set hotkey**
 
@@ -2057,8 +2129,10 @@ So only files you likely need to modify are
 
     - in `bot/commands/monkeys.py`, search `_get_hotkey` and support for new hotkey:
 
-            case "test_monkey":
-                return hotkeys["test monkey"]
+        ```python
+        case "test_monkey":
+            return hotkeys["test monkey"]
+        ```
 
     Here, 
     
@@ -2086,8 +2160,10 @@ So only files you likely need to modify are
     - in `monkeys.py`, search `_update_auto_target_paths`
     - then simply add a new line like this:
 
-            if self._name == "test_monkey" and i == 0 and int(u[2*i]) == 4:
-                self._targeting = "strong"
+        ```python
+        if self._name == "test_monkey" and i == 0 and int(u[2*i]) == 4:
+            self._targeting = "strong"
+        ```
     
     Here, 
     
@@ -2183,29 +2259,31 @@ This in in fact the only mandatory step for adding heroes. However, if hero uses
     - search for method `_change_hero_target` and find following part (or something that looks very similar to it in 
     case this has not been updated) under it:
 
-            match self._hero_name:
-                case "benjamin":
-                    print("???")
-                case "etienne":
-                    if target == "d&q":
-                        if current == "first":
-                            kb_mouse.kb_input(hotkeys["target change"])
-                        elif current == "zone":
-                            kb_mouse.kb_input(hotkeys["target reverse"])
-                    elif target == "first":
-                        if current == "d&q":
-                            kb_mouse.kb_input(hotkeys["target reverse"])
-                        elif current == "zone":
-                            kb_mouse.kb_input(hotkeys["target change"])
-                    elif target == "zone":
-                        if current == "first":
-                            kb_mouse.kb_input(hotkeys["target reverse"])
-                        elif current == "d&q":
-                            kb_mouse.kb_input(hotkeys["target change"])
-                    else:
-                        return self._name, target
-                case _:
-                    return self._normal_targeting(current, target) 
+        ```python
+        match self._hero_name:
+            case "benjamin":
+                print("???")
+            case "etienne":
+                if target == "d&q":
+                    if current == "first":
+                        kb_mouse.kb_input(hotkeys["target change"])
+                    elif current == "zone":
+                        kb_mouse.kb_input(hotkeys["target reverse"])
+                elif target == "first":
+                    if current == "d&q":
+                        kb_mouse.kb_input(hotkeys["target reverse"])
+                    elif current == "zone":
+                        kb_mouse.kb_input(hotkeys["target change"])
+                elif target == "zone":
+                    if current == "first":
+                        kb_mouse.kb_input(hotkeys["target reverse"])
+                    elif current == "d&q":
+                        kb_mouse.kb_input(hotkeys["target change"])
+                else:
+                    return self._name, target
+            case _:
+                return self._normal_targeting(current, target)
+        ```
 
         Here the special cases: all other heroes operate under basic system. 
         

--- a/btd6bot/Files/helpwindow/README.md
+++ b/btd6bot/Files/helpwindow/README.md
@@ -1192,9 +1192,7 @@ it.
     [this section](#any-aspect-ratio) of advanced resolutions guide.
 
 - **Ocr time limit**: How long will bot attempt to search for various text flags before it gives up and attempts to
-return to main menu. Typically, this should never occur so a high value of 300 seconds or more is recommended: this 
-is especially important for apopalypse plans as in those you can have long periods of downtime where bot attempts to 
-place/upgrade a monkey.
+return to main menu. Typically, this should never occur so a high value of 300 seconds or more is recommended
 
 - **Ocr frequency**: Pause interval between most ocr operations, in seconds. Naturally every operation has base cost
 which depends on cpu/gpu speed on top of which this value is then added. Raising this value will greatly decrease 
@@ -1584,17 +1582,25 @@ number or variable END:
 
 Again, no need to include final round block if it has no commands.
 
-On two special cases, you can just use the first if-block
+On a special case, you can just use the first if-block
 
 ```python
     if round == BEGIN:
         ...
 ```
-to include all commands. These are deflation and apopalypse. In fact, for apopalypse, you 
-**have to use only the first round block!**. After first round ends, bot sets internal flag for end round and stops
-processing other rounds.
+to include all commands. This is used in **deflation mode**, but you could technically use this on every single game
+mode.
+- If you do end using this on **non-deflation game modes (= don't use this on deflation plans!)**, for example in apopalypse because you can't bother tracking each round (understandable because pausing is disabled), you should **ALWAYS** write
+
+    ```python
+        round = END
+    ```
+
+  as the very final command, setting bot's round tracking to last round. This avoids the issue with executing all commands on BEGIN round and then waiting bot to skip over all the rounds between BEGIN and END, printing lots of empty rounds.  
+  More importantly, without round = END, while bot is catching up in rounds, game actually finishes. This results the background becoming darker which makes round reading pretty much impossible, leaving bot to hang until ocr time limit is reached (and even with that bot might fail to leave end screen, requiring user to manually reset the state).
+
     
-For examples see *dark_castleEasyDeflation.py* and *infernalMediumApopalypse.py* plan files.
+For examples see *dark_castleEasyDeflation.py* and also *infernalMediumApopalypse.py* where the latter uses only BEGIN round block and thus includes the "round = END".
 
 
 ## **Commands**

--- a/btd6bot/bot/menu_start.py
+++ b/btd6bot/bot/menu_start.py
@@ -10,6 +10,8 @@ import sys
 import time
 
 import pyautogui
+if sys.platform != "darwin":
+    from pynput import keyboard
 
 from bot import _maindata, kb_mouse, locations
 from bot.commands.flow import AutoStart
@@ -153,7 +155,11 @@ def _choose_map(map_name: str) -> bool:
     time.sleep(0.4)
     kb_mouse.click(get_click("menu", "search_map_bar"))
     time.sleep(0.4)
-    pyautogui.write(map_str)  # types map name to search bar.
+    # types map name to search bar
+    if sys.platform == "darwin":    # for mac testers: use pyautogui, pynput caused crashes before
+        pyautogui.write(map_str)
+    else:
+        keyboard.Controller().type(map_str)
     kb_mouse.click(get_click("menu", "choose_map"))
     return True
 

--- a/btd6bot/bot/ocr/ocr.py
+++ b/btd6bot/bot/ocr/ocr.py
@@ -20,7 +20,7 @@ import io
 import os
 import shutil
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 import difflib
 import sys
 import time
@@ -71,7 +71,7 @@ elif sys.platform == "linux":
 
 if TYPE_CHECKING:
     from easyocr import Reader
-    from typing import Any, cast
+    from typing import Any
 
 
 class OcrValues:
@@ -99,31 +99,32 @@ class OcrValues:
 
 
 def _wayland_grab(coordinates: tuple[int, int, int, int]) -> Image.Image:
-    raw_img: Any
+    raw_img: bytes
     tl_x, tl_y, br_x, br_y = coordinates
     width, height = br_x - tl_x, br_y - tl_y
     if width <= 0 or height <= 0:
         raise ValueError("Invalid screenshot dimensions")
-    time.sleep(0.05)
+
+    region = f"{tl_x},{tl_y} {width}x{height}"
+
     try:
-        region = f"{tl_x},{tl_y}, {width}x{height}"
-        cmd = ["grim", "-g", region, "-t", "ppm", "-"]  # write into stdout -> saving images should not be required
-        raw_img = subprocess.check_output(cmd, timeout=5)
+        raw_img = subprocess.check_output(["grim", "-g", region, "-"], timeout=5, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        cprint("grim failed: ", e.stderr)
+        raise RuntimeError(f"grim failed: {e}") from e
+
     return Image.open(io.BytesIO(raw_img)).convert("RGB")
 
 
 def _wayland_pixelcolor(x: float, y: float) -> tuple[int, int, int]:
-    raw_img: Any
+    raw_img: bytes
     px, py = kb_mouse.pixel_position((x, y))
-    time.sleep(0.05)
+    region = f"{px},{py} 1x1"
+
     try:
-        region = f"{px},{py}, 1x1"
-        cmd = ["grim", "-g", region, "-t", "ppm", "-"]
-        raw_img = subprocess.check_output(cmd, timeout=5)
+        raw_img = subprocess.check_output(["grim", "-g", region, "-"], timeout=5, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        cprint("grim failed: ", e.stderr)
+        raise RuntimeError(f"grim failed: {e.output.decode()}") from e
+
     img = Image.open(io.BytesIO(raw_img)).convert("RGB")
     pixel: tuple[int, int, int] = cast(tuple[int, int, int], img.getpixel((0, 0)))  # type cast for mypy
     return pixel

--- a/btd6bot/bot/rounds.py
+++ b/btd6bot/bot/rounds.py
@@ -262,6 +262,8 @@ class Rounds:
         current_round = prev_round + 1
         if current_round == Rounds.begin_round:
             Rounds.start()
+            if mode.lower() == "apopalypse":
+                forward(1)
         elif current_round == Rounds.end_round + 1:
             if _maindata.debug_get_mode() == _maindata.Debug.SETUP_STATIC_STATE:
                 dprint("Reached the end of current plan, stopping here!")
@@ -282,8 +284,6 @@ class Rounds:
                 forward()
             else:
                 dprint(f"Round {current_round}:")
-        elif mode.lower() == "apopalypse":
-            return Rounds.end_round
         else:
             if not AutoStart.called_forward:
                 forward()

--- a/btd6bot/gui/monitoring_window.py
+++ b/btd6bot/gui/monitoring_window.py
@@ -71,9 +71,9 @@ class MonitoringWindow:
         icon = tk.PhotoImage(file=gui_paths.FILES_PATH / "btd6bot.png")
         self.monitoringwindow.iconphoto(True, icon)
         if sys.platform == "linux":
-            self.monitoringwindow.geometry("815x505")
-            self.monitoringwindow.minsize(815, 505)
-            self.monitoringwindow.maxsize(815, 505)
+            self.monitoringwindow.geometry("815x530")
+            self.monitoringwindow.minsize(815, 530)
+            self.monitoringwindow.maxsize(815, 530)
         else:
             self.monitoringwindow.geometry("800x480")
             self.monitoringwindow.minsize(800, 480)

--- a/btd6bot/plans/infernalMediumApopalypse.py
+++ b/btd6bot/plans/infernalMediumApopalypse.py
@@ -29,7 +29,6 @@ def play(data):
         if round == BEGIN:
             sub1 = Monkey("sub", 0.2723958333333, 0.7490740740741)
             sub2 = Monkey("sub", 0.6197916666667, 0.2509259259259)
-            forward(1)
             sub2.upgrade(["0-0-1"])
             sub1.upgrade(["0-0-1"])
             druid1 = Monkey("druid", 0.8333333333333, 0.637962962963)

--- a/btd6bot/plans/infernalMediumApopalypse.py
+++ b/btd6bot/plans/infernalMediumApopalypse.py
@@ -14,7 +14,8 @@ druid 1-3-0
 
 village 0-2-0
 _______________________________________
-Apopalypse round rng might fail you. Should work after a few tries, though.
+Apopalypse round rng might fail you, should work after a few tries, though. This happens on zero monkey knowledge, but
+if you have some of the more important ones, this should work 100% of the time.
 """
 
 from ._plan_imports import *
@@ -65,3 +66,9 @@ def play(data):
             sub2 = Monkey("sub", 0.6197916666667, 0.2509259259259)
             sub2.upgrade(["0-0-1", "0-0-2", "1-0-2", "2-0-2", "2-0-3", "2-0-4"])
             sub1.upgrade(["2-0-4"])
+            # because this plan uses the old BEGIN round only logic, it's necessary to force final round here
+            # otherwise bot needs to catch up each, skipping each round with 0:00 time. 
+            # The actual issue is that bot fails go from 1 to 60 before bot finishes. When the victory screen appears, 
+            # bot is unable to read the rounds because text becomes much darker. It hangs on somewhere between 30-50, 
+            # not being able to progress
+            round = END


### PR DESCRIPTION
This is a follow-up patch to 1.0.1. which tried to add Linux wayland support for wlroots-based displays. That ended up not working, but this should finally fix it by using proper command format for screenshots, default to png format instead of forcing ppm, and properly halt the bot if grim cannot be called.

These Wayland changes + the ones listed below are based on the feedback of @Schnurzel700. Their help is greatly appreciated.

Other changes:
- increased monitoring window height again for Linux, should now properly fit all elements
- updated README.md and INSTALL.md: both will now also display code in their own formats (Python, Bash, Powershell)
- keyboard language issues:
   - updated version and added a "Keyboard languages" section which explains a current issue with keyboards use different languages and how to temporarily fix this by directly editing hotkeys.txt
   - menu_start.py -> _choose_map: switch pyautogui.write() to use pynpyt.Keyboard.Controller.type. Map names should now get properly typed regardless of language used

**Also updated apopalypse game mode handling, here's a bit longer explanation why:**

- previously (before this patch) bot would use a very old implementation which had 2 major quirks:

  1. bot doesn't call forward at all in apopalypse because it automatically starts. Instead it relied on the user to manually call forward(1) at the start of each such plan. Why? I don't remember the original reason, but round handling code was much different back then
  2. after executing first round commands, bot would immediately jump to final round and wait for the end. Why such implementation? In the older version, bot couldn't catch up with round number like it now can. This meant the following could happen:
  - current round would be for example 3
  - in apopalypse, round can be very short, especially in the early game
  - while bot executes commands (places monkeys, uprades them), round 5 already happens and now it's 4
  - bot fails to detect this because it still performed commands and when it's done, it sees round 5 but waits for 4
  - it will stay stuck here until game over
  
   So to avoid this issue: just put all commands under BEGIN round block, let bot execute them. And when the last one is finished, set round to final one and wait. This wouldn't work with time-based stuff like abilities but it was better than always losing.

   Of course this issue was fixed long time ago and if bot sees that current 3 is less than 5 , it just jumps to next round, executes commands, and repeats this until it catches up. But this design was never updated for apopalypse.

And this issue was only detected now (again partially thanks to @Schnurzel700). Because no new apopalypse plans have been added since then, there was not really a reason to test and update this. Currently only **infernalMediumApopalypse** exists and it still used the manual forward(1) call + places all commands under BEGIN block. The manual forward call has now been removed, but code can stay the way it is. Only a single change is added: `round = END` command to force last round and avoid iterating over all the empty rounds between BEGIN and END.

So the actual change is very minimal: in rounds.py -> round_check:

This block

```python
elif mode.lower() == "apopalypse":
    return Rounds.end_round
```

is removed and reworked inside first round block:

```python
if current_round == Rounds.begin_round:
    Rounds.start()
    if mode.lower() == "apopalypse":
        forward(1)
```

Now bot uses forward(1) call automatically. Previously it would skip over the else-block which presses forward() (which would actually still press it twice and nothing would change) and did any kind of round checking.
So round checks are part of apopalypse as they should have been a long time ago.